### PR TITLE
translator cookie config

### DIFF
--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -52,7 +52,11 @@ return [
         'cookie' => [
             'name' => 'dk30Translator',
             'lifetime' => 3600 * 24 * 30,
+            'samesite' => 'Lax',
+            'secure' => true,
+            'httponly' => true
         ],
+
         'default' => 'en',
         'locale' => [
             'en' => 'en_EN',

--- a/src/App/src/Service/TranslateService.php
+++ b/src/App/src/Service/TranslateService.php
@@ -47,11 +47,14 @@ class TranslateService implements TranslateServiceInterface
             setcookie(
                 $this->translatorConfig['cookie']['name'],
                 $languageKey,
-                time() + $this->translatorConfig['cookie']['lifetime'],
-                $config->getCookiePath(),
-                $config->getCookieDomain(),
-                (bool) $config->getCookieSecure(),
-                (bool) $config->getCookieHttpOnly()
+                [
+                    'expires' => time() + $this->translatorConfig['cookie']['lifetime'],
+                    'path' => $config->getCookiePath(),
+                    'domain' => $config->getCookieDomain(),
+                    'samesite' => $this->translatorConfig['cookie']['samesite'],
+                    'secure' => $this->translatorConfig['cookie']['secure'],
+                    'httponly' => $this->translatorConfig['cookie']['httponly']
+                ]
             );
         }
     }


### PR DESCRIPTION
#72 
Added new cookie configuration keys: "httponly", "secure", "samesite" to local.php.dist (also add them in local.php)
The new keys are used in addTranslateCookie()