### PR TITLE
Issue #365: Removed `laminas/laminas-i18n`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0",
-        "ext-gettext": "*",
         "dotkernel/dot-cache": "^4.3.0",
         "dotkernel/dot-cli": "^3.9.0",
         "dotkernel/dot-data-fixtures": "^1.4.0",
@@ -46,28 +45,26 @@
         "friendsofphp/proxy-manager-lts": "^1.0.18",
         "laminas/laminas-component-installer": "^3.5.0",
         "laminas/laminas-config-aggregator": "^1.18.0",
-        "laminas/laminas-i18n": "^2.29.0",
-        "laminas/laminas-math": "^3.8.1",
-        "mezzio/mezzio": "^3.20.1",
+        "mezzio/mezzio": "^3.21.0",
         "mezzio/mezzio-authentication-oauth2": "^2.11.0",
-        "mezzio/mezzio-authorization-rbac": "^1.8.0",
-        "mezzio/mezzio-cors": "^1.13.0",
-        "mezzio/mezzio-fastroute": "^3.12.0",
+        "mezzio/mezzio-authorization-rbac": "^1.9.0",
+        "mezzio/mezzio-cors": "^1.14.0",
+        "mezzio/mezzio-fastroute": "^3.13.0",
         "ramsey/uuid-doctrine": "^2.1.0",
         "roave/psr-container-doctrine": "^5.2.2"
     },
     "require-dev": {
         "filp/whoops": "^2.18.0",
-        "laminas/laminas-coding-standard": "^3.0.1",
+        "laminas/laminas-coding-standard": "^3.1.0",
         "laminas/laminas-development-mode": "^3.13.0",
         "mezzio/mezzio-tooling": "^2.10.1",
-        "phpunit/phpunit": "^10.5.45",
-        "roave/security-advisories": "dev-latest",
-        "vincentlanglet/twig-cs-fixer": "^3.5.1",
-        "phpstan/phpstan": "^2.1.11",
-        "phpstan/phpstan-doctrine": "^2.0.2",
+        "phpstan/phpstan": "^2.1.17",
+        "phpstan/phpstan-doctrine": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.6",
-        "symfony/var-dumper": "^7.2.3"
+        "phpunit/phpunit": "^10.5.46",
+        "roave/security-advisories": "dev-latest",
+        "symfony/var-dumper": "^7.3.0",
+        "vincentlanglet/twig-cs-fixer": "^3.7.1"
     },
     "autoload": {
         "psr-4": {

--- a/config/config.php
+++ b/config/config.php
@@ -8,6 +8,9 @@ $cacheConfig = [
     'config_cache_path' => 'data/cache/config-cache.php',
 ];
 
+/**
+ * @see https://github.com/dotkernel/admin/issues/365
+ */
 if (! class_exists('\Laminas\I18n\View\Helper\AbstractTranslatorHelper')) {
     class_alias(
         Admin\App\Laminas\I18n\View\Helper\AbstractTranslatorHelper::class,

--- a/config/config.php
+++ b/config/config.php
@@ -8,6 +8,16 @@ $cacheConfig = [
     'config_cache_path' => 'data/cache/config-cache.php',
 ];
 
+if (! class_exists('\Laminas\I18n\View\Helper\AbstractTranslatorHelper')) {
+    class_alias(
+        Admin\App\Laminas\I18n\View\Helper\AbstractTranslatorHelper::class,
+        '\Laminas\I18n\View\Helper\AbstractTranslatorHelper'
+    );
+}
+if (! class_exists('\Laminas\I18n\Validator\IsFloat')) {
+    class_alias(Admin\App\Laminas\I18n\Validator\IsFloat::class, '\Laminas\I18n\Validator\IsFloat');
+}
+
 // @codingStandardsIgnoreStart
 $aggregator = new Laminas\ConfigAggregator\ConfigAggregator([
     // Laminas packages

--- a/src/Admin/src/Handler/Account/PostAccountLoginHandler.php
+++ b/src/Admin/src/Handler/Account/PostAccountLoginHandler.php
@@ -24,6 +24,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 
+use function assert;
+
 class PostAccountLoginHandler implements RequestHandlerInterface
 {
     #[Inject(
@@ -40,7 +42,7 @@ class PostAccountLoginHandler implements RequestHandlerInterface
         protected AdminServiceInterface $adminService,
         protected AdminLoginServiceInterface $adminLoginService,
         protected RouterInterface $router,
-        protected LaminasAuthenticationServiceInterface&AuthenticationServiceInterface $authenticationService,
+        protected LaminasAuthenticationServiceInterface $authenticationService,
         protected FlashMessengerInterface $messenger,
         protected FormsPlugin $forms,
         protected LoginForm $loginForm,
@@ -50,6 +52,7 @@ class PostAccountLoginHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        assert($this->authenticationService instanceof AuthenticationServiceInterface);
         if ($this->authenticationService->hasIdentity()) {
             return new RedirectResponse($this->router->generateUri('app::index-redirect'));
         }

--- a/src/App/src/Laminas/I18n/Validator/IsFloat.php
+++ b/src/App/src/Laminas/I18n/Validator/IsFloat.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Admin\App\Laminas\I18n\Validator;
+
+use Laminas\Validator\AbstractValidator;
+
+class IsFloat extends AbstractValidator
+{
+    /**
+     * @inheritDoc
+     */
+    public function isValid($value): false
+    {
+        return false;
+    }
+}

--- a/src/App/src/Laminas/I18n/View/Helper/AbstractTranslatorHelper.php
+++ b/src/App/src/Laminas/I18n/View/Helper/AbstractTranslatorHelper.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Admin\App\Laminas\I18n\View\Helper;
+
+use Laminas\View\Helper\AbstractHelper;
+
+abstract class AbstractTranslatorHelper extends AbstractHelper
+{
+    public function getTranslator(): null
+    {
+        return null;
+    }
+}

--- a/src/User/src/Handler/PostUserAvatarEditHandler.php
+++ b/src/User/src/Handler/PostUserAvatarEditHandler.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Admin\User\Handler;
 
 use Admin\App\Exception\NotFoundException;
+use Admin\App\Form\AbstractForm;
 use Admin\User\Form\EditUserAvatarForm;
 use Admin\User\Form\EditUserForm;
 use Admin\User\Service\UserAvatarServiceInterface;
+use Admin\User\Service\UserRoleServiceInterface;
 use Admin\User\Service\UserServiceInterface;
 use Core\App\Message;
+use Core\User\Entity\UserRole;
+use Core\User\Enum\UserRoleEnum;
 use Dot\DependencyInjection\Attribute\Inject;
 use Dot\FlashMessenger\FlashMessengerInterface;
 use Dot\Log\Logger;
@@ -23,12 +27,18 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 
+use function array_filter;
+use function array_map;
 use function array_merge;
 
+/**
+ * @phpstan-import-type SelectDataType from AbstractForm
+ */
 class PostUserAvatarEditHandler implements RequestHandlerInterface
 {
     #[Inject(
         UserServiceInterface::class,
+        UserRoleServiceInterface::class,
         UserAvatarServiceInterface::class,
         RouterInterface::class,
         TemplateRendererInterface::class,
@@ -39,6 +49,7 @@ class PostUserAvatarEditHandler implements RequestHandlerInterface
     )]
     public function __construct(
         protected UserServiceInterface $userService,
+        protected UserRoleServiceInterface $userRoleService,
         protected UserAvatarServiceInterface $userAvatarService,
         protected RouterInterface $router,
         protected TemplateRendererInterface $template,
@@ -59,6 +70,19 @@ class PostUserAvatarEditHandler implements RequestHandlerInterface
             return new EmptyResponse(StatusCodeInterface::STATUS_NOT_FOUND);
         }
 
+        /** @var UserRole[] $userRoles */
+        $userRoles = $this->userRoleService->getUserRoleRepository()->findAll();
+        $userRoles = array_map(
+        /** @return SelectDataType */
+            fn (UserRole $userRole): array => [
+                'label'    => $userRole->getName()->value,
+                'value'    => $userRole->getUuid()->toString(),
+                'selected' => $user->hasRole($userRole),
+            ],
+            $userRoles
+        );
+        $userRoles = array_filter($userRoles, fn (array $role) => $role['label'] !== UserRoleEnum::Guest->value);
+
         $this->editUserAvatarForm
             ->setAttribute(
                 'action',
@@ -69,7 +93,8 @@ class PostUserAvatarEditHandler implements RequestHandlerInterface
             ->setAttribute(
                 'action',
                 $this->router->generateUri('user::user-edit', ['uuid' => $user->getUuid()->toString()])
-            );
+            )
+            ->setRoles($userRoles);
 
         try {
             $this->editUserAvatarForm->setData(

--- a/test/Unit/Admin/Adapter/AuthenticationAdapterTest.php
+++ b/test/Unit/Admin/Adapter/AuthenticationAdapterTest.php
@@ -100,7 +100,6 @@ class AuthenticationAdapterTest extends UnitTest
     /**
      * @throws MockObjectException
      * @throws ORMException
-     * @group testing
      */
     public function testWillNotAuthenticateWithInvalidIdentityClassConfig(): void
     {


### PR DESCRIPTION
### In this PR:

- bumped dependencies
- added class aliases with minimal functionality for the two `laminas-i18n` classes used but not required by `laminas-form`:
    - [src/App/src/Laminas/I18n/Validator/IsFloat.php](https://github.com/dotkernel/admin/blob/issue-365/src/App/src/Laminas/I18n/Validator/IsFloat.php)
    - [src/App/src/Laminas/I18n/View/Helper/AbstractTranslatorHelper.php](https://github.com/dotkernel/admin/blob/issue-365/src/App/src/Laminas/I18n/View/Helper/AbstractTranslatorHelper.php)
- removed dependency: `laminas/laminas-i18n`
- removed dependency: `laminas/laminas-math`
- removed dependency: `ext-gettext`
- fixed a bug in `src/Admin/src/Handler/Account/PostAccountLoginHandler.php`
- fixed a bug in `src/User/src/Handler/PostUserAvatarEditHandler.php`
- removed unused `@group` annotation from `test/Unit/Admin/Adapter/AuthenticationAdapterTest.php`

#### Notes:

1. The two temporary classes (`IsFloat.php` and `AbstractTranslatorHelper.php`) and the `class_alias`es from `config/config.php` will be removed once we can upgrade `laminas/laminas-form` to the next major version which should not contain these "soft-dependencies".
2. Out of curiosity, I checked if we could raise `PHPUnit` to version **11** or **12**.
The latest version of **11.5.21** worked well, there was only one deprecation to fix (the one with the `@group` annotation I mentioned above).
Version **12** supports **PHP ^8.3**, so until we remove **PHP 8.2** and add **PHP 8.4** support that is not an option.