### PR TITLE
Issue #368: Switch from `UUID4` to `UUID7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ Open a web browser and visit `http://localhost:8080/`.
 You should see the **Dotkernel Admin** login page.
 If you ran the migrations you will have an admin user in the database with the following credentials:
 
-- **Identity**: `admin`
-- **Password**: `dotadmin`
+* **Identity**: `admin`
+* **Password**: `dotadmin`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Choosing to inject any extra ConfigProvider would cause having duplicates which 
 
 > **Do not enable development mode in production!**
 
-If you're installing the project for development, you should **enable** development mode, by running:
+If you're installing the project for development, you should **enable** development mode by running:
 
 ```shell
 composer development-enable
@@ -75,7 +75,7 @@ You can **disable** development mode by running:
 composer development-disable
 ```
 
-You can **check** development status by running:
+You can **check** the development status by running:
 
 ```shell
 composer development-status
@@ -83,7 +83,7 @@ composer development-status
 
 ### Prepare config files
 
-* **optional**: in order to run/create tests, duplicate `config/autoload/local.test.php.dist` as `config/autoload/local.test.php` <- this creates a new in-memory database that your tests will run on
+* **optional**: to run/create tests, duplicate `config/autoload/local.test.php.dist` as `config/autoload/local.test.php` <- this creates a new in-memory database that your tests will run on
 
 ### Setup database
 
@@ -134,13 +134,13 @@ More details on how fixtures work can be found in `dotkernel/dot-data-fixtures` 
 
 ### Mail configuration
 
-If your application will send emails, you must configure an outgoing mail server under `config/autoload/mail.global.php`.
+If your application sends emails, you must configure an outgoing mail server under `config/autoload/mail.global.php`.
 
 ### Sync GeoLite2 databases
 
 #### Full sync
 
-You can download/update all GeoLite2 databases at once, by running the following command:
+You can download/update all GeoLite2 databases at once by running the following command:
 
 ```shell
 php ./bin/cli.php geoip:synchronize
@@ -156,7 +156,7 @@ country: n/a -> 2015-10-21 04:29:00
 
 #### Selective sync
 
-You can download/update a specific GeoLite2 database, by running the following command:
+You can download/update a specific GeoLite2 database by running the following command:
 
 ```shell
 php ./bin/cli.php geoip:synchronize -d <database>
@@ -197,7 +197,7 @@ npm run prod
 
 ### Test the installation
 
-If you are using virtual hosts as described in the [Dotkernel documentation] (https://docs.dotkernel.org/development/) you need you modify the permissions of the `data`, `public/uploads` and `log` folders:
+If you are using virtual hosts as described in the [Dotkernel documentation] (https://docs.dotkernel.org/development/), you need to modify the permissions of the `data`, `public/uploads` and `log` folders:
 
 ```shell
 chmod -R 777 data

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "mezzio/mezzio-authorization-rbac": "^1.9.0",
         "mezzio/mezzio-cors": "^1.14.0",
         "mezzio/mezzio-fastroute": "^3.13.0",
+        "ramsey/uuid": "^4.5.0",
         "ramsey/uuid-doctrine": "^2.1.0",
         "roave/psr-container-doctrine": "^5.2.2"
     },

--- a/src/Core/src/App/src/Entity/AbstractEntity.php
+++ b/src/Core/src/App/src/Entity/AbstractEntity.php
@@ -22,7 +22,7 @@ abstract class AbstractEntity implements ArraySerializableInterface, EntityInter
 
     public function __construct()
     {
-        $this->uuid = Uuid::uuid4();
+        $this->uuid = Uuid::uuid7();
     }
 
     public function getUuid(): UuidInterface

--- a/src/User/src/Service/UserAvatarService.php
+++ b/src/User/src/Service/UserAvatarService.php
@@ -117,7 +117,7 @@ class UserAvatarService implements UserAvatarServiceInterface
     {
         return sprintf(
             'avatar-%s.%s',
-            Uuid::uuid4()->toString(),
+            Uuid::uuid7()->toString(),
             self::EXTENSIONS[$fileType]
         );
     }


### PR DESCRIPTION
UUID7 was introduced into `ramsey/uuid` in version [4.5.0](https://github.com/ramsey/uuid/releases/tag/4.5.0).
Being that ramsey/uuid-doctrine accepts a wide range of versions of ramsey/uuid (ramsey/uuid: ^3.9.7 || ^4.0), we need to make sure that we work with a version of ramsey/uuid which has uuid7 implemented, else the [QA checks for lowest](https://github.com/dotkernel/admin/actions/runs/15391821414) will fail.