### PR TITLE
updated auth guards

### DIFF
--- a/config/autoload/authorization-guards.global.php
+++ b/config/autoload/authorization-guards.global.php
@@ -18,8 +18,8 @@ return [
                         'type'    => 'RoutePermission',
                         'options' => [
                             'rules' => [
-                                'admin::admin-login-form'        => ['unauthenticated'],
-                                'admin::admin-login'             => ['unauthenticated'],
+                                'admin::admin-login-form'        => ['authenticated', 'unauthenticated'],
+                                'admin::admin-login'             => ['authenticated', 'unauthenticated'],
                                 'admin::admin-create-form'       => ['authenticated'],
                                 'admin::admin-create'            => ['authenticated'],
                                 'admin::admin-delete-form'       => ['authenticated'],


### PR DESCRIPTION
auth guards was set up to allow acces to these routes only if the admin is not authenticated
now updated to allow access in both auth/unauth cases, which enables the redirect to dashboard if authenticated (logged in)

```php
'admin::admin-login-form'        => ['authenticated', 'unauthenticated'],
'admin::admin-login'             => ['authenticated', 'unauthenticated'],
```