### PR TITLE
Updated all handler names to match route names

### DIFF
--- a/src/Admin/src/ConfigProvider.php
+++ b/src/Admin/src/ConfigProvider.php
@@ -11,20 +11,20 @@ use Admin\Admin\Form\AccountForm;
 use Admin\Admin\Form\CreateAdminForm;
 use Admin\Admin\Form\DeleteAdminForm;
 use Admin\Admin\Form\EditAdminForm;
-use Admin\Admin\Handler\Account\GetAccountEditFormHandler;
-use Admin\Admin\Handler\Account\GetAccountLoginFormHandler;
-use Admin\Admin\Handler\Account\GetAccountLogoutHandler;
-use Admin\Admin\Handler\Account\PostAccountChangePasswordHandler;
-use Admin\Admin\Handler\Account\PostAccountEditHandler;
-use Admin\Admin\Handler\Account\PostAccountLoginHandler;
-use Admin\Admin\Handler\Admin\GetAdminCreateFormHandler;
-use Admin\Admin\Handler\Admin\GetAdminDeleteFormHandler;
-use Admin\Admin\Handler\Admin\GetAdminEditFormHandler;
-use Admin\Admin\Handler\Admin\GetAdminListHandler;
-use Admin\Admin\Handler\Admin\GetAdminLoginListHandler;
-use Admin\Admin\Handler\Admin\PostAdminCreateHandler;
-use Admin\Admin\Handler\Admin\PostAdminDeleteHandler;
-use Admin\Admin\Handler\Admin\PostAdminEditHandler;
+use Admin\Admin\Handler\Account\GetEditAccountFormHandler;
+use Admin\Admin\Handler\Account\GetLoginAccountFormHandler;
+use Admin\Admin\Handler\Account\GetLogoutAccountHandler;
+use Admin\Admin\Handler\Account\PostChangeAccountPasswordHandler;
+use Admin\Admin\Handler\Account\PostEditAccountHandler;
+use Admin\Admin\Handler\Account\PostLoginAccountHandler;
+use Admin\Admin\Handler\Admin\GetCreateAdminFormHandler;
+use Admin\Admin\Handler\Admin\GetDeleteAdminFormHandler;
+use Admin\Admin\Handler\Admin\GetEditAdminFormHandler;
+use Admin\Admin\Handler\Admin\GetListAdminHandler;
+use Admin\Admin\Handler\Admin\GetListAdminLoginHandler;
+use Admin\Admin\Handler\Admin\PostCreateAdminHandler;
+use Admin\Admin\Handler\Admin\PostDeleteAdminHandler;
+use Admin\Admin\Handler\Admin\PostEditAdminHandler;
 use Admin\Admin\Service\AdminLoginService;
 use Admin\Admin\Service\AdminLoginServiceInterface;
 use Admin\Admin\Service\AdminRoleService;
@@ -74,20 +74,20 @@ class ConfigProvider
                 CreateAdminForm::class => [AdminRoleDelegator::class],
             ],
             'factories'  => [
-                GetAdminCreateFormHandler::class        => AttributedServiceFactory::class,
-                PostAdminCreateHandler::class           => AttributedServiceFactory::class,
-                GetAdminEditFormHandler::class          => AttributedServiceFactory::class,
-                PostAdminEditHandler::class             => AttributedServiceFactory::class,
-                GetAdminDeleteFormHandler::class        => AttributedServiceFactory::class,
-                PostAdminDeleteHandler::class           => AttributedServiceFactory::class,
-                GetAdminListHandler::class              => AttributedServiceFactory::class,
-                GetAdminLoginListHandler::class         => AttributedServiceFactory::class,
-                GetAccountEditFormHandler::class        => AttributedServiceFactory::class,
-                PostAccountEditHandler::class           => AttributedServiceFactory::class,
-                PostAccountChangePasswordHandler::class => AttributedServiceFactory::class,
-                GetAccountLoginFormHandler::class       => AttributedServiceFactory::class,
-                PostAccountLoginHandler::class          => AttributedServiceFactory::class,
-                GetAccountLogoutHandler::class          => AttributedServiceFactory::class,
+                GetCreateAdminFormHandler::class        => AttributedServiceFactory::class,
+                PostCreateAdminHandler::class           => AttributedServiceFactory::class,
+                GetEditAdminFormHandler::class          => AttributedServiceFactory::class,
+                PostEditAdminHandler::class             => AttributedServiceFactory::class,
+                GetDeleteAdminFormHandler::class        => AttributedServiceFactory::class,
+                PostDeleteAdminHandler::class           => AttributedServiceFactory::class,
+                GetListAdminHandler::class              => AttributedServiceFactory::class,
+                GetListAdminLoginHandler::class         => AttributedServiceFactory::class,
+                GetEditAccountFormHandler::class        => AttributedServiceFactory::class,
+                PostEditAccountHandler::class           => AttributedServiceFactory::class,
+                PostChangeAccountPasswordHandler::class => AttributedServiceFactory::class,
+                GetLoginAccountFormHandler::class       => AttributedServiceFactory::class,
+                PostLoginAccountHandler::class          => AttributedServiceFactory::class,
+                GetLogoutAccountHandler::class          => AttributedServiceFactory::class,
                 AuthenticationAdapter::class            => AttributedServiceFactory::class,
                 AdminService::class                     => AttributedServiceFactory::class,
                 AdminRoleService::class                 => AttributedServiceFactory::class,

--- a/src/Admin/src/Handler/Account/GetEditAccountFormHandler.php
+++ b/src/Admin/src/Handler/Account/GetEditAccountFormHandler.php
@@ -6,66 +6,44 @@ namespace Admin\Admin\Handler\Account;
 
 use Admin\Admin\Form\AccountForm;
 use Admin\Admin\Form\ChangePasswordForm;
-use Admin\Admin\InputFilter\ChangePasswordInputFilter;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
-use Core\App\Message;
 use Dot\DependencyInjection\Attribute\Inject;
 use Dot\FlashMessenger\FlashMessengerInterface;
-use Dot\Log\Logger;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Authentication\AuthenticationServiceInterface;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\HtmlResponse;
-use Laminas\Diactoros\Response\RedirectResponse;
 use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Throwable;
 
-/**
- * @phpstan-import-type ChangePasswordDataType from ChangePasswordInputFilter
- */
-class PostAccountChangePasswordHandler implements RequestHandlerInterface
+class GetEditAccountFormHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminServiceInterface::class,
         RouterInterface::class,
         TemplateRendererInterface::class,
         AuthenticationServiceInterface::class,
-        FlashMessengerInterface::class,
         AccountForm::class,
         ChangePasswordForm::class,
-        'dot-log.default_logger',
+        FlashMessengerInterface::class,
     )]
     public function __construct(
         protected AdminServiceInterface $adminService,
         protected RouterInterface $router,
         protected TemplateRendererInterface $template,
         protected AuthenticationServiceInterface $authenticationService,
-        protected FlashMessengerInterface $messenger,
         protected AccountForm $accountForm,
         protected ChangePasswordForm $changePasswordForm,
-        protected Logger $logger,
+        protected FlashMessengerInterface $messenger,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        /** @var iterable<array<string, string|string[]>> $data */
-        $data = $request->getParsedBody();
-        $this->changePasswordForm->setData($data);
-        if (! $this->changePasswordForm->isValid()) {
-            return new HtmlResponse(
-                $this->template->render('admin::view-account', [
-                    'accountForm'        => $this->accountForm->prepare(),
-                    'changePasswordForm' => $this->changePasswordForm->prepare(),
-                ])
-            );
-        }
-
         try {
             $admin = $this->adminService->findAdmin($this->authenticationService->getIdentity()->getUuid());
         } catch (NotFoundException $exception) {
@@ -78,25 +56,13 @@ class PostAccountChangePasswordHandler implements RequestHandlerInterface
         $this->changePasswordForm
             ->setAttribute('action', $this->router->generateUri('admin::change-account-password'));
 
-        try {
-            /** @var ChangePasswordDataType $data */
-            $data = $this->changePasswordForm->getData();
-            if ($admin->verifyPassword($data['currentPassword'])) {
-                $this->adminService->saveAdmin($data, $admin);
-                $this->messenger->addSuccess(Message::ACCOUNT_UPDATED);
-            } else {
-                $this->messenger->addError(Message::INVALID_CURRENT_PASSWORD);
-            }
-        } catch (Throwable $exception) {
-            $this->logger->err('Change password', [
-                'error' => $exception->getMessage(),
-                'file'  => $exception->getFile(),
-                'line'  => $exception->getLine(),
-                'trace' => $exception->getTraceAsString(),
-            ]);
-            $this->messenger->addError(Message::AN_ERROR_OCCURRED);
-        }
+        $this->accountForm->bind($admin);
 
-        return new RedirectResponse($this->router->generateUri('admin::edit-account-form'));
+        return new HtmlResponse(
+            $this->template->render('admin::view-account', [
+                'accountForm'        => $this->accountForm->prepare(),
+                'changePasswordForm' => $this->changePasswordForm->prepare(),
+            ])
+        );
     }
 }

--- a/src/Admin/src/Handler/Account/GetLoginAccountFormHandler.php
+++ b/src/Admin/src/Handler/Account/GetLoginAccountFormHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetAccountLoginFormHandler implements RequestHandlerInterface
+class GetLoginAccountFormHandler implements RequestHandlerInterface
 {
     #[Inject(
         RouterInterface::class,

--- a/src/Admin/src/Handler/Account/GetLogoutAccountHandler.php
+++ b/src/Admin/src/Handler/Account/GetLogoutAccountHandler.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetAccountLogoutHandler implements RequestHandlerInterface
+class GetLogoutAccountHandler implements RequestHandlerInterface
 {
     #[Inject(
         RouterInterface::class,

--- a/src/Admin/src/Handler/Account/PostChangeAccountPasswordHandler.php
+++ b/src/Admin/src/Handler/Account/PostChangeAccountPasswordHandler.php
@@ -6,10 +6,8 @@ namespace Admin\Admin\Handler\Account;
 
 use Admin\Admin\Form\AccountForm;
 use Admin\Admin\Form\ChangePasswordForm;
-use Admin\Admin\InputFilter\EditAccountInputFilter;
+use Admin\Admin\InputFilter\ChangePasswordInputFilter;
 use Admin\Admin\Service\AdminServiceInterface;
-use Admin\App\Exception\BadRequestException;
-use Admin\App\Exception\ConflictException;
 use Admin\App\Exception\NotFoundException;
 use Core\App\Message;
 use Dot\DependencyInjection\Attribute\Inject;
@@ -28,18 +26,18 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 
 /**
- * @phpstan-import-type EditAccountDataType from EditAccountInputFilter
+ * @phpstan-import-type ChangePasswordDataType from ChangePasswordInputFilter
  */
-class PostAccountEditHandler implements RequestHandlerInterface
+class PostChangeAccountPasswordHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminServiceInterface::class,
         RouterInterface::class,
         TemplateRendererInterface::class,
         AuthenticationServiceInterface::class,
+        FlashMessengerInterface::class,
         AccountForm::class,
         ChangePasswordForm::class,
-        FlashMessengerInterface::class,
         'dot-log.default_logger',
     )]
     public function __construct(
@@ -47,9 +45,9 @@ class PostAccountEditHandler implements RequestHandlerInterface
         protected RouterInterface $router,
         protected TemplateRendererInterface $template,
         protected AuthenticationServiceInterface $authenticationService,
+        protected FlashMessengerInterface $messenger,
         protected AccountForm $accountForm,
         protected ChangePasswordForm $changePasswordForm,
-        protected FlashMessengerInterface $messenger,
         protected Logger $logger,
     ) {
     }
@@ -58,8 +56,8 @@ class PostAccountEditHandler implements RequestHandlerInterface
     {
         /** @var iterable<array<string, string|string[]>> $data */
         $data = $request->getParsedBody();
-        $this->accountForm->setData($data);
-        if (! $this->accountForm->isValid()) {
+        $this->changePasswordForm->setData($data);
+        if (! $this->changePasswordForm->isValid()) {
             return new HtmlResponse(
                 $this->template->render('admin::view-account', [
                     'accountForm'        => $this->accountForm->prepare(),
@@ -81,14 +79,16 @@ class PostAccountEditHandler implements RequestHandlerInterface
             ->setAttribute('action', $this->router->generateUri('admin::change-account-password'));
 
         try {
-            /** @var EditAccountDataType $data */
-            $data = $this->accountForm->getData();
-            $this->adminService->saveAdmin($data, $admin);
-            $this->messenger->addSuccess(Message::ACCOUNT_UPDATED);
-        } catch (BadRequestException | ConflictException | NotFoundException $exception) {
-            $this->messenger->addError($exception->getMessage());
+            /** @var ChangePasswordDataType $data */
+            $data = $this->changePasswordForm->getData();
+            if ($admin->verifyPassword($data['currentPassword'])) {
+                $this->adminService->saveAdmin($data, $admin);
+                $this->messenger->addSuccess(Message::ACCOUNT_UPDATED);
+            } else {
+                $this->messenger->addError(Message::INVALID_CURRENT_PASSWORD);
+            }
         } catch (Throwable $exception) {
-            $this->logger->err('Update admin', [
+            $this->logger->err('Change password', [
                 'error' => $exception->getMessage(),
                 'file'  => $exception->getFile(),
                 'line'  => $exception->getLine(),
@@ -97,6 +97,6 @@ class PostAccountEditHandler implements RequestHandlerInterface
             $this->messenger->addError(Message::AN_ERROR_OCCURRED);
         }
 
-        return new RedirectResponse($this->router->generateUri('admin::edit-account'));
+        return new RedirectResponse($this->router->generateUri('admin::edit-account-form'));
     }
 }

--- a/src/Admin/src/Handler/Account/PostEditAccountHandler.php
+++ b/src/Admin/src/Handler/Account/PostEditAccountHandler.php
@@ -6,21 +6,31 @@ namespace Admin\Admin\Handler\Account;
 
 use Admin\Admin\Form\AccountForm;
 use Admin\Admin\Form\ChangePasswordForm;
+use Admin\Admin\InputFilter\EditAccountInputFilter;
 use Admin\Admin\Service\AdminServiceInterface;
+use Admin\App\Exception\BadRequestException;
+use Admin\App\Exception\ConflictException;
 use Admin\App\Exception\NotFoundException;
+use Core\App\Message;
 use Dot\DependencyInjection\Attribute\Inject;
 use Dot\FlashMessenger\FlashMessengerInterface;
+use Dot\Log\Logger;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Authentication\AuthenticationServiceInterface;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\RedirectResponse;
 use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Throwable;
 
-class GetAccountEditFormHandler implements RequestHandlerInterface
+/**
+ * @phpstan-import-type EditAccountDataType from EditAccountInputFilter
+ */
+class PostEditAccountHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminServiceInterface::class,
@@ -30,6 +40,7 @@ class GetAccountEditFormHandler implements RequestHandlerInterface
         AccountForm::class,
         ChangePasswordForm::class,
         FlashMessengerInterface::class,
+        'dot-log.default_logger',
     )]
     public function __construct(
         protected AdminServiceInterface $adminService,
@@ -39,11 +50,24 @@ class GetAccountEditFormHandler implements RequestHandlerInterface
         protected AccountForm $accountForm,
         protected ChangePasswordForm $changePasswordForm,
         protected FlashMessengerInterface $messenger,
+        protected Logger $logger,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        /** @var iterable<array<string, string|string[]>> $data */
+        $data = $request->getParsedBody();
+        $this->accountForm->setData($data);
+        if (! $this->accountForm->isValid()) {
+            return new HtmlResponse(
+                $this->template->render('admin::view-account', [
+                    'accountForm'        => $this->accountForm->prepare(),
+                    'changePasswordForm' => $this->changePasswordForm->prepare(),
+                ])
+            );
+        }
+
         try {
             $admin = $this->adminService->findAdmin($this->authenticationService->getIdentity()->getUuid());
         } catch (NotFoundException $exception) {
@@ -56,13 +80,23 @@ class GetAccountEditFormHandler implements RequestHandlerInterface
         $this->changePasswordForm
             ->setAttribute('action', $this->router->generateUri('admin::change-account-password'));
 
-        $this->accountForm->bind($admin);
+        try {
+            /** @var EditAccountDataType $data */
+            $data = $this->accountForm->getData();
+            $this->adminService->saveAdmin($data, $admin);
+            $this->messenger->addSuccess(Message::ACCOUNT_UPDATED);
+        } catch (BadRequestException | ConflictException | NotFoundException $exception) {
+            $this->messenger->addError($exception->getMessage());
+        } catch (Throwable $exception) {
+            $this->logger->err('Update admin', [
+                'error' => $exception->getMessage(),
+                'file'  => $exception->getFile(),
+                'line'  => $exception->getLine(),
+                'trace' => $exception->getTraceAsString(),
+            ]);
+            $this->messenger->addError(Message::AN_ERROR_OCCURRED);
+        }
 
-        return new HtmlResponse(
-            $this->template->render('admin::view-account', [
-                'accountForm'        => $this->accountForm->prepare(),
-                'changePasswordForm' => $this->changePasswordForm->prepare(),
-            ])
-        );
+        return new RedirectResponse($this->router->generateUri('admin::edit-account'));
     }
 }

--- a/src/Admin/src/Handler/Account/PostLoginAccountHandler.php
+++ b/src/Admin/src/Handler/Account/PostLoginAccountHandler.php
@@ -26,7 +26,7 @@ use Throwable;
 
 use function assert;
 
-class PostAccountLoginHandler implements RequestHandlerInterface
+class PostLoginAccountHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminServiceInterface::class,

--- a/src/Admin/src/Handler/Admin/GetCreateAdminFormHandler.php
+++ b/src/Admin/src/Handler/Admin/GetCreateAdminFormHandler.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Admin\User\Handler;
+namespace Admin\Admin\Handler\Admin;
 
-use Admin\User\Form\CreateUserForm;
+use Admin\Admin\Form\CreateAdminForm;
 use Dot\DependencyInjection\Attribute\Inject;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Router\RouterInterface;
@@ -13,27 +13,27 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetUserCreateFormHandler implements RequestHandlerInterface
+class GetCreateAdminFormHandler implements RequestHandlerInterface
 {
     #[Inject(
         RouterInterface::class,
         TemplateRendererInterface::class,
-        CreateUserForm::class,
+        CreateAdminForm::class,
     )]
     public function __construct(
         protected RouterInterface $router,
         protected TemplateRendererInterface $template,
-        protected CreateUserForm $createUserForm,
+        protected CreateAdminForm $createAdminForm,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $this->createUserForm->setAttribute('action', $this->router->generateUri('user::create-user'));
+        $this->createAdminForm->setAttribute('action', $this->router->generateUri('admin::create-admin'));
 
         return new HtmlResponse(
-            $this->template->render('user::create-user-form', [
-                'form' => $this->createUserForm->prepare(),
+            $this->template->render('admin::create-admin-form', [
+                'form' => $this->createAdminForm->prepare(),
             ])
         );
     }

--- a/src/Admin/src/Handler/Admin/GetDeleteAdminFormHandler.php
+++ b/src/Admin/src/Handler/Admin/GetDeleteAdminFormHandler.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Admin\User\Handler;
+namespace Admin\Admin\Handler\Admin;
 
+use Admin\Admin\Form\DeleteAdminForm;
+use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
-use Admin\User\Form\DeleteUserForm;
-use Admin\User\Service\UserServiceInterface;
 use Dot\DependencyInjection\Attribute\Inject;
 use Dot\FlashMessenger\FlashMessengerInterface;
 use Fig\Http\Message\StatusCodeInterface;
@@ -18,43 +18,43 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetUserDeleteFormHandler implements RequestHandlerInterface
+class GetDeleteAdminFormHandler implements RequestHandlerInterface
 {
     #[Inject(
-        UserServiceInterface::class,
+        AdminServiceInterface::class,
         RouterInterface::class,
         TemplateRendererInterface::class,
         FlashMessengerInterface::class,
-        DeleteUserForm::class,
+        DeleteAdminForm::class,
     )]
     public function __construct(
-        protected UserServiceInterface $userService,
+        protected AdminServiceInterface $adminService,
         protected RouterInterface $router,
         protected TemplateRendererInterface $template,
         protected FlashMessengerInterface $messenger,
-        protected DeleteUserForm $deleteUserForm,
+        protected DeleteAdminForm $deleteAdminForm,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
-            $user = $this->userService->findUser($request->getAttribute('uuid'));
+            $admin = $this->adminService->findAdmin($request->getAttribute('uuid'));
         } catch (NotFoundException $exception) {
             $this->messenger->addError($exception->getMessage());
 
             return new EmptyResponse(StatusCodeInterface::STATUS_NOT_FOUND);
         }
 
-        $this->deleteUserForm->setAttribute(
+        $this->deleteAdminForm->setAttribute(
             'action',
-            $this->router->generateUri('user::delete-user', ['uuid' => $user->getUuid()->toString()])
+            $this->router->generateUri('admin::delete-admin', ['uuid' => $admin->getUuid()->toString()])
         );
 
         return new HtmlResponse(
-            $this->template->render('user::delete-user-form', [
-                'form' => $this->deleteUserForm->prepare(),
-                'user' => $user,
+            $this->template->render('admin::delete-admin-form', [
+                'form'  => $this->deleteAdminForm->prepare(),
+                'admin' => $admin,
             ]),
         );
     }

--- a/src/Admin/src/Handler/Admin/GetEditAdminFormHandler.php
+++ b/src/Admin/src/Handler/Admin/GetEditAdminFormHandler.php
@@ -26,7 +26,7 @@ use function array_map;
 /**
  * @phpstan-import-type SelectDataType from AbstractForm
  */
-class GetAdminEditFormHandler implements RequestHandlerInterface
+class GetEditAdminFormHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminServiceInterface::class,

--- a/src/Admin/src/Handler/Admin/GetListAdminHandler.php
+++ b/src/Admin/src/Handler/Admin/GetListAdminHandler.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetAdminListHandler implements RequestHandlerInterface
+class GetListAdminHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminServiceInterface::class,

--- a/src/Admin/src/Handler/Admin/GetListAdminLoginHandler.php
+++ b/src/Admin/src/Handler/Admin/GetListAdminLoginHandler.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetAdminLoginListHandler implements RequestHandlerInterface
+class GetListAdminLoginHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminLoginServiceInterface::class,

--- a/src/Admin/src/Handler/Admin/PostCreateAdminHandler.php
+++ b/src/Admin/src/Handler/Admin/PostCreateAdminHandler.php
@@ -25,7 +25,7 @@ use Throwable;
 /**
  * @phpstan-import-type CreateAdminDataType from CreateAdminInputFilter
  */
-class PostAdminCreateHandler implements RequestHandlerInterface
+class PostCreateAdminHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminServiceInterface::class,

--- a/src/Admin/src/Handler/Admin/PostDeleteAdminHandler.php
+++ b/src/Admin/src/Handler/Admin/PostDeleteAdminHandler.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Admin\User\Handler;
+namespace Admin\Admin\Handler\Admin;
 
+use Admin\Admin\Form\DeleteAdminForm;
+use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
-use Admin\User\Form\DeleteUserForm;
-use Admin\User\Service\UserAvatarServiceInterface;
-use Admin\User\Service\UserServiceInterface;
 use Core\App\Message;
 use Dot\DependencyInjection\Attribute\Inject;
 use Dot\FlashMessenger\FlashMessengerInterface;
@@ -22,24 +21,22 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 
-class PostUserDeleteHandler implements RequestHandlerInterface
+class PostDeleteAdminHandler implements RequestHandlerInterface
 {
     #[Inject(
-        UserServiceInterface::class,
-        UserAvatarServiceInterface::class,
+        AdminServiceInterface::class,
         RouterInterface::class,
         TemplateRendererInterface::class,
         FlashMessengerInterface::class,
-        DeleteUserForm::class,
+        DeleteAdminForm::class,
         'dot-log.default_logger',
     )]
     public function __construct(
-        protected UserServiceInterface $userService,
-        protected UserAvatarServiceInterface $userAvatarService,
+        protected AdminServiceInterface $adminService,
         protected RouterInterface $router,
         protected TemplateRendererInterface $template,
         protected FlashMessengerInterface $messenger,
-        protected DeleteUserForm $deleteUserForm,
+        protected DeleteAdminForm $deleteAdminForm,
         protected Logger $logger,
     ) {
     }
@@ -47,40 +44,39 @@ class PostUserDeleteHandler implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
-            $user = $this->userService->findUser($request->getAttribute('uuid'));
+            $admin = $this->adminService->findAdmin($request->getAttribute('uuid'));
         } catch (NotFoundException $exception) {
             $this->messenger->addError($exception->getMessage());
 
             return new EmptyResponse(StatusCodeInterface::STATUS_NOT_FOUND);
         }
 
-        $this->deleteUserForm->setAttribute(
+        $this->deleteAdminForm->setAttribute(
             'action',
-            $this->router->generateUri('user::delete-user', ['uuid' => $user->getUuid()->toString()])
+            $this->router->generateUri('admin::delete-admin', ['uuid' => $admin->getUuid()->toString()])
         );
 
         try {
             /** @var iterable<array<string, string|string[]>> $data */
             $data = $request->getParsedBody();
-            $this->deleteUserForm->setData($data);
-            if ($this->deleteUserForm->isValid()) {
-                $this->userService->deleteUser($user);
-                $this->userAvatarService->deleteAvatar($user);
-                $this->messenger->addSuccess(Message::USER_DELETED);
+            $this->deleteAdminForm->setData($data);
+            if ($this->deleteAdminForm->isValid()) {
+                $this->adminService->deleteAdmin($admin);
+                $this->messenger->addSuccess(Message::ADMIN_DELETED);
 
                 return new EmptyResponse(StatusCodeInterface::STATUS_CREATED);
             }
 
             return new HtmlResponse(
-                $this->template->render('user::delete-user-form', [
-                    'form' => $this->deleteUserForm->prepare(),
-                    'user' => $user,
+                $this->template->render('admin::delete-admin-form', [
+                    'form'  => $this->deleteAdminForm->prepare(),
+                    'admin' => $admin,
                 ]),
                 StatusCodeInterface::STATUS_UNPROCESSABLE_ENTITY
             );
         } catch (Throwable $exception) {
             $this->messenger->addError(Message::AN_ERROR_OCCURRED);
-            $this->logger->err('Create user', [
+            $this->logger->err('Delete admin', [
                 'error' => $exception->getMessage(),
                 'file'  => $exception->getFile(),
                 'line'  => $exception->getLine(),

--- a/src/Admin/src/Handler/Admin/PostEditAdminHandler.php
+++ b/src/Admin/src/Handler/Admin/PostEditAdminHandler.php
@@ -33,7 +33,7 @@ use function array_map;
  * @phpstan-import-type CreateAdminDataType from CreateAdminInputFilter
  * @phpstan-import-type SelectDataType from AbstractForm
  */
-class PostAdminEditHandler implements RequestHandlerInterface
+class PostEditAdminHandler implements RequestHandlerInterface
 {
     #[Inject(
         AdminServiceInterface::class,

--- a/src/Admin/src/RoutesDelegator.php
+++ b/src/Admin/src/RoutesDelegator.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Admin\Admin;
 
-use Admin\Admin\Handler\Account\GetAccountEditFormHandler;
-use Admin\Admin\Handler\Account\GetAccountLoginFormHandler;
-use Admin\Admin\Handler\Account\GetAccountLogoutHandler;
-use Admin\Admin\Handler\Account\PostAccountChangePasswordHandler;
-use Admin\Admin\Handler\Account\PostAccountEditHandler;
-use Admin\Admin\Handler\Account\PostAccountLoginHandler;
-use Admin\Admin\Handler\Admin\GetAdminCreateFormHandler;
-use Admin\Admin\Handler\Admin\GetAdminDeleteFormHandler;
-use Admin\Admin\Handler\Admin\GetAdminEditFormHandler;
-use Admin\Admin\Handler\Admin\GetAdminListHandler;
-use Admin\Admin\Handler\Admin\GetAdminLoginListHandler;
-use Admin\Admin\Handler\Admin\PostAdminCreateHandler;
-use Admin\Admin\Handler\Admin\PostAdminDeleteHandler;
-use Admin\Admin\Handler\Admin\PostAdminEditHandler;
+use Admin\Admin\Handler\Account\GetEditAccountFormHandler;
+use Admin\Admin\Handler\Account\GetLoginAccountFormHandler;
+use Admin\Admin\Handler\Account\GetLogoutAccountHandler;
+use Admin\Admin\Handler\Account\PostChangeAccountPasswordHandler;
+use Admin\Admin\Handler\Account\PostEditAccountHandler;
+use Admin\Admin\Handler\Account\PostLoginAccountHandler;
+use Admin\Admin\Handler\Admin\GetCreateAdminFormHandler;
+use Admin\Admin\Handler\Admin\GetDeleteAdminFormHandler;
+use Admin\Admin\Handler\Admin\GetEditAdminFormHandler;
+use Admin\Admin\Handler\Admin\GetListAdminHandler;
+use Admin\Admin\Handler\Admin\GetListAdminLoginHandler;
+use Admin\Admin\Handler\Admin\PostCreateAdminHandler;
+use Admin\Admin\Handler\Admin\PostDeleteAdminHandler;
+use Admin\Admin\Handler\Admin\PostEditAdminHandler;
 use Dot\Router\RouteCollectorInterface;
 use Mezzio\Application;
 use Psr\Container\ContainerExceptionInterface;
@@ -36,23 +36,23 @@ class RoutesDelegator
         $routeCollector = $container->get(RouteCollectorInterface::class);
 
         $routeCollector->group('/admin')
-            ->get('/create-admin', GetAdminCreateFormHandler::class, 'admin::create-admin-form')
-            ->post('/create-admin', PostAdminCreateHandler::class, 'admin::create-admin')
-            ->get('/delete-admin/{uuid}', GetAdminDeleteFormHandler::class, 'admin::delete-admin-form')
-            ->post('/delete-admin/{uuid}', PostAdminDeleteHandler::class, 'admin::delete-admin')
-            ->get('/edit-admin/{uuid}', GetAdminEditFormHandler::class, 'admin::edit-admin-form')
-            ->post('/edit-admin/{uuid}', PostAdminEditHandler::class, 'admin::edit-admin')
-            ->get('/list-admin', GetAdminListHandler::class, 'admin::list-admin')
-            ->get('/list-admin-login', GetAdminLoginListHandler::class, 'admin::list-admin-login');
+            ->get('/create-admin', GetCreateAdminFormHandler::class, 'admin::create-admin-form')
+            ->post('/create-admin', PostCreateAdminHandler::class, 'admin::create-admin')
+            ->get('/delete-admin/{uuid}', GetDeleteAdminFormHandler::class, 'admin::delete-admin-form')
+            ->post('/delete-admin/{uuid}', PostDeleteAdminHandler::class, 'admin::delete-admin')
+            ->get('/edit-admin/{uuid}', GetEditAdminFormHandler::class, 'admin::edit-admin-form')
+            ->post('/edit-admin/{uuid}', PostEditAdminHandler::class, 'admin::edit-admin')
+            ->get('/list-admin', GetListAdminHandler::class, 'admin::list-admin')
+            ->get('/list-admin-login', GetListAdminLoginHandler::class, 'admin::list-admin-login');
 
         $routeCollector->group('/admin')
-            ->post('/change-password', PostAccountChangePasswordHandler::class, 'admin::change-account-password')
-            ->get('/edit-account', GetAccountEditFormHandler::class, 'admin::edit-account-form')
-            ->post('/edit-account', PostAccountEditHandler::class, 'admin::edit-account');
+            ->post('/change-password', PostChangeAccountPasswordHandler::class, 'admin::change-account-password')
+            ->get('/edit-account', GetEditAccountFormHandler::class, 'admin::edit-account-form')
+            ->post('/edit-account', PostEditAccountHandler::class, 'admin::edit-account');
 
-        $routeCollector->get('/admin/login', GetAccountLoginFormHandler::class, 'admin::login-admin-form');
-        $routeCollector->post('/admin/login', PostAccountLoginHandler::class, 'admin::login-admin');
-        $routeCollector->get('/admin/logout', GetAccountLogoutHandler::class, 'admin::logout-admin');
+        $routeCollector->get('/admin/login', GetLoginAccountFormHandler::class, 'admin::login-admin-form');
+        $routeCollector->post('/admin/login', PostLoginAccountHandler::class, 'admin::login-admin');
+        $routeCollector->get('/admin/logout', GetLogoutAccountHandler::class, 'admin::logout-admin');
 
         return $callback();
     }

--- a/src/Dashboard/src/ConfigProvider.php
+++ b/src/Dashboard/src/ConfigProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Admin\Dashboard;
 
-use Admin\Dashboard\Handler\GetDashboardViewHandler;
+use Admin\Dashboard\Handler\GetViewDashboardHandler;
 use Dot\DependencyInjection\Factory\AttributedServiceFactory;
 use Mezzio\Application;
 
@@ -44,7 +44,7 @@ class ConfigProvider
                 Application::class => [RoutesDelegator::class],
             ],
             'factories'  => [
-                GetDashboardViewHandler::class => AttributedServiceFactory::class,
+                GetViewDashboardHandler::class => AttributedServiceFactory::class,
             ],
         ];
     }

--- a/src/Dashboard/src/Handler/GetViewDashboardHandler.php
+++ b/src/Dashboard/src/Handler/GetViewDashboardHandler.php
@@ -2,39 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Admin\Admin\Handler\Admin;
+namespace Admin\Dashboard\Handler;
 
-use Admin\Admin\Form\CreateAdminForm;
 use Dot\DependencyInjection\Attribute\Inject;
 use Laminas\Diactoros\Response\HtmlResponse;
-use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetAdminCreateFormHandler implements RequestHandlerInterface
+class GetViewDashboardHandler implements RequestHandlerInterface
 {
     #[Inject(
-        RouterInterface::class,
         TemplateRendererInterface::class,
-        CreateAdminForm::class,
     )]
     public function __construct(
-        protected RouterInterface $router,
         protected TemplateRendererInterface $template,
-        protected CreateAdminForm $createAdminForm,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $this->createAdminForm->setAttribute('action', $this->router->generateUri('admin::create-admin'));
-
         return new HtmlResponse(
-            $this->template->render('admin::create-admin-form', [
-                'form' => $this->createAdminForm->prepare(),
-            ])
+            $this->template->render('dashboard::dashboard')
         );
     }
 }

--- a/src/Dashboard/src/RoutesDelegator.php
+++ b/src/Dashboard/src/RoutesDelegator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Admin\Dashboard;
 
-use Admin\Dashboard\Handler\GetDashboardViewHandler;
+use Admin\Dashboard\Handler\GetViewDashboardHandler;
 use Dot\Router\RouteCollectorInterface;
 use Mezzio\Application;
 use Psr\Container\ContainerExceptionInterface;
@@ -22,7 +22,7 @@ class RoutesDelegator
         /** @var RouteCollectorInterface $routeCollector */
         $routeCollector = $container->get(RouteCollectorInterface::class);
 
-        $routeCollector->get('/dashboard', GetDashboardViewHandler::class, 'dashboard::view-dashboard');
+        $routeCollector->get('/dashboard', GetViewDashboardHandler::class, 'dashboard::view-dashboard');
 
         return $callback();
     }

--- a/src/Page/src/ConfigProvider.php
+++ b/src/Page/src/ConfigProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Admin\Page;
 
-use Admin\Page\Handler\GetPageViewHandler;
+use Admin\Page\Handler\GetViewPageHandler;
 use Dot\DependencyInjection\Factory\AttributedServiceFactory;
 use Mezzio\Application;
 
@@ -44,7 +44,7 @@ class ConfigProvider
                 Application::class => [RoutesDelegator::class],
             ],
             'factories'  => [
-                GetPageViewHandler::class => AttributedServiceFactory::class,
+                GetViewPageHandler::class => AttributedServiceFactory::class,
             ],
         ];
     }

--- a/src/Page/src/Handler/GetViewPageHandler.php
+++ b/src/Page/src/Handler/GetViewPageHandler.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Admin\Dashboard\Handler;
+namespace Admin\Page\Handler;
 
 use Dot\DependencyInjection\Attribute\Inject;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Router\RouteResult;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetDashboardViewHandler implements RequestHandlerInterface
+class GetViewPageHandler implements RequestHandlerInterface
 {
     #[Inject(
         TemplateRendererInterface::class,
@@ -23,8 +24,10 @@ class GetDashboardViewHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $template = $request->getAttribute(RouteResult::class)->getMatchedRouteName();
+
         return new HtmlResponse(
-            $this->template->render('dashboard::dashboard')
+            $this->template->render($template)
         );
     }
 }

--- a/src/Page/src/RoutesDelegator.php
+++ b/src/Page/src/RoutesDelegator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Admin\Page;
 
-use Admin\Page\Handler\GetPageViewHandler;
+use Admin\Page\Handler\GetViewPageHandler;
 use Dot\Router\RouteCollectorInterface;
 use Mezzio\Application;
 use Psr\Container\ContainerExceptionInterface;
@@ -29,7 +29,7 @@ class RoutesDelegator
             foreach ($moduleRoutes as $routeUri => $templateName) {
                 $routeCollector->get(
                     sprintf('/%s/%s', $prefix, $routeUri),
-                    [GetPageViewHandler::class],
+                    [GetViewPageHandler::class],
                     sprintf('%s::%s', $prefix, $templateName)
                 );
             }

--- a/src/Setting/src/ConfigProvider.php
+++ b/src/Setting/src/ConfigProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Admin\Setting;
 
-use Admin\Setting\Handler\GetSettingViewHandler;
-use Admin\Setting\Handler\PostSettingStoreHandler;
+use Admin\Setting\Handler\GetViewSettingHandler;
+use Admin\Setting\Handler\PostStoreSettingHandler;
 use Admin\Setting\Service\SettingService;
 use Admin\Setting\Service\SettingServiceInterface;
 use Dot\DependencyInjection\Factory\AttributedServiceFactory;
@@ -43,8 +43,8 @@ class ConfigProvider
                 Application::class => [RoutesDelegator::class],
             ],
             'factories'  => [
-                PostSettingStoreHandler::class => AttributedServiceFactory::class,
-                GetSettingViewHandler::class   => AttributedServiceFactory::class,
+                PostStoreSettingHandler::class => AttributedServiceFactory::class,
+                GetViewSettingHandler::class   => AttributedServiceFactory::class,
                 SettingService::class          => AttributedServiceFactory::class,
             ],
             'aliases'    => [

--- a/src/Setting/src/Handler/GetViewSettingHandler.php
+++ b/src/Setting/src/Handler/GetViewSettingHandler.php
@@ -22,7 +22,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use function assert;
 use function is_array;
 
-class GetSettingViewHandler implements RequestHandlerInterface
+class GetViewSettingHandler implements RequestHandlerInterface
 {
     #[Inject(
         AuthenticationServiceInterface::class,

--- a/src/Setting/src/Handler/PostStoreSettingHandler.php
+++ b/src/Setting/src/Handler/PostStoreSettingHandler.php
@@ -23,7 +23,7 @@ use function assert;
 use function is_array;
 use function json_decode;
 
-class PostSettingStoreHandler implements RequestHandlerInterface
+class PostStoreSettingHandler implements RequestHandlerInterface
 {
     #[Inject(
         AuthenticationServiceInterface::class,

--- a/src/Setting/src/RoutesDelegator.php
+++ b/src/Setting/src/RoutesDelegator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Admin\Setting;
 
-use Admin\Setting\Handler\GetSettingViewHandler;
-use Admin\Setting\Handler\PostSettingStoreHandler;
+use Admin\Setting\Handler\GetViewSettingHandler;
+use Admin\Setting\Handler\PostStoreSettingHandler;
 use Dot\Router\RouteCollectorInterface;
 use Mezzio\Application;
 use Psr\Container\ContainerExceptionInterface;
@@ -24,8 +24,8 @@ class RoutesDelegator
         $routeCollector = $container->get(RouteCollectorInterface::class);
 
         $routeCollector->group('/setting')
-            ->get('/{identifier}', GetSettingViewHandler::class, 'setting::view-setting')
-            ->post('/{identifier}', PostSettingStoreHandler::class, 'setting::store-setting');
+            ->get('/{identifier}', GetViewSettingHandler::class, 'setting::view-setting')
+            ->post('/{identifier}', PostStoreSettingHandler::class, 'setting::store-setting');
 
         return $callback();
     }

--- a/src/User/src/ConfigProvider.php
+++ b/src/User/src/ConfigProvider.php
@@ -8,14 +8,14 @@ use Admin\User\Delegator\UserRoleDelegator;
 use Admin\User\Form\CreateUserForm;
 use Admin\User\Form\DeleteUserForm;
 use Admin\User\Form\EditUserForm;
-use Admin\User\Handler\GetUserCreateFormHandler;
-use Admin\User\Handler\GetUserDeleteFormHandler;
-use Admin\User\Handler\GetUserEditFormHandler;
-use Admin\User\Handler\GetUserListHandler;
-use Admin\User\Handler\PostUserAvatarEditHandler;
-use Admin\User\Handler\PostUserCreateHandler;
-use Admin\User\Handler\PostUserDeleteHandler;
-use Admin\User\Handler\PostUserEditHandler;
+use Admin\User\Handler\GetCreateUserFormHandler;
+use Admin\User\Handler\GetDeleteUserFormHandler;
+use Admin\User\Handler\GetEditUserFormHandler;
+use Admin\User\Handler\GetListUserHandler;
+use Admin\User\Handler\PostCreateUserHandler;
+use Admin\User\Handler\PostDeleteUserHandler;
+use Admin\User\Handler\PostEditUserAvatarHandler;
+use Admin\User\Handler\PostEditUserHandler;
 use Admin\User\Service\UserAvatarService;
 use Admin\User\Service\UserAvatarServiceInterface;
 use Admin\User\Service\UserRoleService;
@@ -64,14 +64,14 @@ class ConfigProvider
                 CreateUserForm::class => [UserRoleDelegator::class],
             ],
             'factories'  => [
-                GetUserCreateFormHandler::class  => AttributedServiceFactory::class,
-                GetUserDeleteFormHandler::class  => AttributedServiceFactory::class,
-                GetUserEditFormHandler::class    => AttributedServiceFactory::class,
-                GetUserListHandler::class        => AttributedServiceFactory::class,
-                PostUserAvatarEditHandler::class => AttributedServiceFactory::class,
-                PostUserCreateHandler::class     => AttributedServiceFactory::class,
-                PostUserDeleteHandler::class     => AttributedServiceFactory::class,
-                PostUserEditHandler::class       => AttributedServiceFactory::class,
+                GetCreateUserFormHandler::class  => AttributedServiceFactory::class,
+                GetDeleteUserFormHandler::class  => AttributedServiceFactory::class,
+                GetEditUserFormHandler::class    => AttributedServiceFactory::class,
+                GetListUserHandler::class        => AttributedServiceFactory::class,
+                PostEditUserAvatarHandler::class => AttributedServiceFactory::class,
+                PostCreateUserHandler::class     => AttributedServiceFactory::class,
+                PostDeleteUserHandler::class     => AttributedServiceFactory::class,
+                PostEditUserHandler::class       => AttributedServiceFactory::class,
                 UserAvatarService::class         => AttributedServiceFactory::class,
                 UserRoleService::class           => AttributedServiceFactory::class,
                 UserService::class               => AttributedServiceFactory::class,

--- a/src/User/src/Handler/GetCreateUserFormHandler.php
+++ b/src/User/src/Handler/GetCreateUserFormHandler.php
@@ -2,32 +2,39 @@
 
 declare(strict_types=1);
 
-namespace Admin\Page\Handler;
+namespace Admin\User\Handler;
 
+use Admin\User\Form\CreateUserForm;
 use Dot\DependencyInjection\Attribute\Inject;
 use Laminas\Diactoros\Response\HtmlResponse;
-use Mezzio\Router\RouteResult;
+use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetPageViewHandler implements RequestHandlerInterface
+class GetCreateUserFormHandler implements RequestHandlerInterface
 {
     #[Inject(
+        RouterInterface::class,
         TemplateRendererInterface::class,
+        CreateUserForm::class,
     )]
     public function __construct(
+        protected RouterInterface $router,
         protected TemplateRendererInterface $template,
+        protected CreateUserForm $createUserForm,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $template = $request->getAttribute(RouteResult::class)->getMatchedRouteName();
+        $this->createUserForm->setAttribute('action', $this->router->generateUri('user::create-user'));
 
         return new HtmlResponse(
-            $this->template->render($template)
+            $this->template->render('user::create-user-form', [
+                'form' => $this->createUserForm->prepare(),
+            ])
         );
     }
 }

--- a/src/User/src/Handler/GetDeleteUserFormHandler.php
+++ b/src/User/src/Handler/GetDeleteUserFormHandler.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Admin\Admin\Handler\Admin;
+namespace Admin\User\Handler;
 
-use Admin\Admin\Form\DeleteAdminForm;
-use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
+use Admin\User\Form\DeleteUserForm;
+use Admin\User\Service\UserServiceInterface;
 use Dot\DependencyInjection\Attribute\Inject;
 use Dot\FlashMessenger\FlashMessengerInterface;
 use Fig\Http\Message\StatusCodeInterface;
@@ -18,43 +18,43 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetAdminDeleteFormHandler implements RequestHandlerInterface
+class GetDeleteUserFormHandler implements RequestHandlerInterface
 {
     #[Inject(
-        AdminServiceInterface::class,
+        UserServiceInterface::class,
         RouterInterface::class,
         TemplateRendererInterface::class,
         FlashMessengerInterface::class,
-        DeleteAdminForm::class,
+        DeleteUserForm::class,
     )]
     public function __construct(
-        protected AdminServiceInterface $adminService,
+        protected UserServiceInterface $userService,
         protected RouterInterface $router,
         protected TemplateRendererInterface $template,
         protected FlashMessengerInterface $messenger,
-        protected DeleteAdminForm $deleteAdminForm,
+        protected DeleteUserForm $deleteUserForm,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
-            $admin = $this->adminService->findAdmin($request->getAttribute('uuid'));
+            $user = $this->userService->findUser($request->getAttribute('uuid'));
         } catch (NotFoundException $exception) {
             $this->messenger->addError($exception->getMessage());
 
             return new EmptyResponse(StatusCodeInterface::STATUS_NOT_FOUND);
         }
 
-        $this->deleteAdminForm->setAttribute(
+        $this->deleteUserForm->setAttribute(
             'action',
-            $this->router->generateUri('admin::delete-admin', ['uuid' => $admin->getUuid()->toString()])
+            $this->router->generateUri('user::delete-user', ['uuid' => $user->getUuid()->toString()])
         );
 
         return new HtmlResponse(
-            $this->template->render('admin::delete-admin-form', [
-                'form'  => $this->deleteAdminForm->prepare(),
-                'admin' => $admin,
+            $this->template->render('user::delete-user-form', [
+                'form' => $this->deleteUserForm->prepare(),
+                'user' => $user,
             ]),
         );
     }

--- a/src/User/src/Handler/GetEditUserFormHandler.php
+++ b/src/User/src/Handler/GetEditUserFormHandler.php
@@ -29,7 +29,7 @@ use function array_map;
 /**
  * @phpstan-import-type SelectDataType from AbstractForm
  */
-class GetUserEditFormHandler implements RequestHandlerInterface
+class GetEditUserFormHandler implements RequestHandlerInterface
 {
     #[Inject(
         UserServiceInterface::class,

--- a/src/User/src/Handler/GetListUserHandler.php
+++ b/src/User/src/Handler/GetListUserHandler.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class GetUserListHandler implements RequestHandlerInterface
+class GetListUserHandler implements RequestHandlerInterface
 {
     #[Inject(
         UserServiceInterface::class,

--- a/src/User/src/Handler/PostCreateUserHandler.php
+++ b/src/User/src/Handler/PostCreateUserHandler.php
@@ -29,7 +29,7 @@ use Throwable;
 /**
  * @phpstan-import-type CreateUserDataType from CreateUserInputFilter
  */
-class PostUserCreateHandler implements RequestHandlerInterface
+class PostCreateUserHandler implements RequestHandlerInterface
 {
     /**
      * @param array<non-empty-string, mixed> $config

--- a/src/User/src/Handler/PostDeleteUserHandler.php
+++ b/src/User/src/Handler/PostDeleteUserHandler.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Admin\Admin\Handler\Admin;
+namespace Admin\User\Handler;
 
-use Admin\Admin\Form\DeleteAdminForm;
-use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
+use Admin\User\Form\DeleteUserForm;
+use Admin\User\Service\UserAvatarServiceInterface;
+use Admin\User\Service\UserServiceInterface;
 use Core\App\Message;
 use Dot\DependencyInjection\Attribute\Inject;
 use Dot\FlashMessenger\FlashMessengerInterface;
@@ -21,22 +22,24 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 
-class PostAdminDeleteHandler implements RequestHandlerInterface
+class PostDeleteUserHandler implements RequestHandlerInterface
 {
     #[Inject(
-        AdminServiceInterface::class,
+        UserServiceInterface::class,
+        UserAvatarServiceInterface::class,
         RouterInterface::class,
         TemplateRendererInterface::class,
         FlashMessengerInterface::class,
-        DeleteAdminForm::class,
+        DeleteUserForm::class,
         'dot-log.default_logger',
     )]
     public function __construct(
-        protected AdminServiceInterface $adminService,
+        protected UserServiceInterface $userService,
+        protected UserAvatarServiceInterface $userAvatarService,
         protected RouterInterface $router,
         protected TemplateRendererInterface $template,
         protected FlashMessengerInterface $messenger,
-        protected DeleteAdminForm $deleteAdminForm,
+        protected DeleteUserForm $deleteUserForm,
         protected Logger $logger,
     ) {
     }
@@ -44,39 +47,40 @@ class PostAdminDeleteHandler implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
-            $admin = $this->adminService->findAdmin($request->getAttribute('uuid'));
+            $user = $this->userService->findUser($request->getAttribute('uuid'));
         } catch (NotFoundException $exception) {
             $this->messenger->addError($exception->getMessage());
 
             return new EmptyResponse(StatusCodeInterface::STATUS_NOT_FOUND);
         }
 
-        $this->deleteAdminForm->setAttribute(
+        $this->deleteUserForm->setAttribute(
             'action',
-            $this->router->generateUri('admin::delete-admin', ['uuid' => $admin->getUuid()->toString()])
+            $this->router->generateUri('user::delete-user', ['uuid' => $user->getUuid()->toString()])
         );
 
         try {
             /** @var iterable<array<string, string|string[]>> $data */
             $data = $request->getParsedBody();
-            $this->deleteAdminForm->setData($data);
-            if ($this->deleteAdminForm->isValid()) {
-                $this->adminService->deleteAdmin($admin);
-                $this->messenger->addSuccess(Message::ADMIN_DELETED);
+            $this->deleteUserForm->setData($data);
+            if ($this->deleteUserForm->isValid()) {
+                $this->userService->deleteUser($user);
+                $this->userAvatarService->deleteAvatar($user);
+                $this->messenger->addSuccess(Message::USER_DELETED);
 
                 return new EmptyResponse(StatusCodeInterface::STATUS_CREATED);
             }
 
             return new HtmlResponse(
-                $this->template->render('admin::delete-admin-form', [
-                    'form'  => $this->deleteAdminForm->prepare(),
-                    'admin' => $admin,
+                $this->template->render('user::delete-user-form', [
+                    'form' => $this->deleteUserForm->prepare(),
+                    'user' => $user,
                 ]),
                 StatusCodeInterface::STATUS_UNPROCESSABLE_ENTITY
             );
         } catch (Throwable $exception) {
             $this->messenger->addError(Message::AN_ERROR_OCCURRED);
-            $this->logger->err('Delete admin', [
+            $this->logger->err('Create user', [
                 'error' => $exception->getMessage(),
                 'file'  => $exception->getFile(),
                 'line'  => $exception->getLine(),

--- a/src/User/src/Handler/PostEditUserAvatarHandler.php
+++ b/src/User/src/Handler/PostEditUserAvatarHandler.php
@@ -34,7 +34,7 @@ use function array_merge;
 /**
  * @phpstan-import-type SelectDataType from AbstractForm
  */
-class PostUserAvatarEditHandler implements RequestHandlerInterface
+class PostEditUserAvatarHandler implements RequestHandlerInterface
 {
     #[Inject(
         UserServiceInterface::class,

--- a/src/User/src/Handler/PostEditUserHandler.php
+++ b/src/User/src/Handler/PostEditUserHandler.php
@@ -36,7 +36,7 @@ use function array_map;
  * @phpstan-import-type CreateUserDataType from CreateUserInputFilter
  * @phpstan-import-type SelectDataType from AbstractForm
  */
-class PostUserEditHandler implements RequestHandlerInterface
+class PostEditUserHandler implements RequestHandlerInterface
 {
     #[Inject(
         UserServiceInterface::class,

--- a/src/User/src/RoutesDelegator.php
+++ b/src/User/src/RoutesDelegator.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Admin\User;
 
-use Admin\User\Handler\GetUserCreateFormHandler;
-use Admin\User\Handler\GetUserDeleteFormHandler;
-use Admin\User\Handler\GetUserEditFormHandler;
-use Admin\User\Handler\GetUserListHandler;
-use Admin\User\Handler\PostUserAvatarEditHandler;
-use Admin\User\Handler\PostUserCreateHandler;
-use Admin\User\Handler\PostUserDeleteHandler;
-use Admin\User\Handler\PostUserEditHandler;
+use Admin\User\Handler\GetCreateUserFormHandler;
+use Admin\User\Handler\GetDeleteUserFormHandler;
+use Admin\User\Handler\GetEditUserFormHandler;
+use Admin\User\Handler\GetListUserHandler;
+use Admin\User\Handler\PostCreateUserHandler;
+use Admin\User\Handler\PostDeleteUserHandler;
+use Admin\User\Handler\PostEditUserAvatarHandler;
+use Admin\User\Handler\PostEditUserHandler;
 use Dot\Router\RouteCollectorInterface;
 use Mezzio\Application;
 use Psr\Container\ContainerExceptionInterface;
@@ -30,14 +30,14 @@ class RoutesDelegator
         $routeCollector = $container->get(RouteCollectorInterface::class);
 
         $routeCollector->group('/user')
-            ->get('/create-user', GetUserCreateFormHandler::class, 'user::create-user-form')
-            ->post('/create-user', PostUserCreateHandler::class, 'user::create-user')
-            ->get('/delete-user/{uuid}', GetUserDeleteFormHandler::class, 'user::delete-user-form')
-            ->post('/delete-user/{uuid}', PostUserDeleteHandler::class, 'user::delete-user')
-            ->get('/edit-user/{uuid}', GetUserEditFormHandler::class, 'user::edit-user-form')
-            ->post('/edit-user/{uuid}', PostUserEditHandler::class, 'user::edit-user')
-            ->post('/edit-user-avatar/{uuid}', PostUserAvatarEditHandler::class, 'user::edit-user-avatar')
-            ->get('/list-user', GetUserListHandler::class, 'user::list-user');
+            ->get('/create-user', GetCreateUserFormHandler::class, 'user::create-user-form')
+            ->post('/create-user', PostCreateUserHandler::class, 'user::create-user')
+            ->get('/delete-user/{uuid}', GetDeleteUserFormHandler::class, 'user::delete-user-form')
+            ->post('/delete-user/{uuid}', PostDeleteUserHandler::class, 'user::delete-user')
+            ->get('/edit-user/{uuid}', GetEditUserFormHandler::class, 'user::edit-user-form')
+            ->post('/edit-user/{uuid}', PostEditUserHandler::class, 'user::edit-user')
+            ->post('/edit-user-avatar/{uuid}', PostEditUserAvatarHandler::class, 'user::edit-user-avatar')
+            ->get('/list-user', GetListUserHandler::class, 'user::list-user');
 
         return $callback();
     }

--- a/test/Unit/Admin/Handler/Account/GetAccountEditFormHandlerTest.php
+++ b/test/Unit/Admin/Handler/Account/GetAccountEditFormHandlerTest.php
@@ -6,7 +6,7 @@ namespace AdminTest\Unit\Admin\Handler\Account;
 
 use Admin\Admin\Form\AccountForm;
 use Admin\Admin\Form\ChangePasswordForm;
-use Admin\Admin\Handler\Account\GetAccountEditFormHandler;
+use Admin\Admin\Handler\Account\GetEditAccountFormHandler;
 use Admin\Admin\Service\AdminServiceInterface;
 use AdminTest\Unit\UnitTest;
 use Core\Admin\Entity\Admin;
@@ -45,7 +45,7 @@ class GetAccountEditFormHandlerTest extends UnitTest
 
         $adminService->method('getAdminRepository')->willReturn($adminRepository);
 
-        $handler = new GetAccountEditFormHandler(
+        $handler = new GetEditAccountFormHandler(
             $adminService,
             $router,
             $template,

--- a/test/Unit/Admin/Handler/Account/GetAccountLoginFormHandlerTest.php
+++ b/test/Unit/Admin/Handler/Account/GetAccountLoginFormHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AdminTest\Unit\Admin\Handler\Account;
 
 use Admin\Admin\Form\LoginForm;
-use Admin\Admin\Handler\Account\GetAccountLoginFormHandler;
+use Admin\Admin\Handler\Account\GetLoginAccountFormHandler;
 use Admin\App\Plugin\FormsPlugin;
 use AdminTest\Unit\UnitTest;
 use Dot\FlashMessenger\FlashMessengerInterface;
@@ -33,7 +33,7 @@ class GetAccountLoginFormHandlerTest extends UnitTest
 
         $authenticationService->method('hasIdentity')->willReturn(true);
 
-        $handler = new GetAccountLoginFormHandler(
+        $handler = new GetLoginAccountFormHandler(
             $router,
             $template,
             $authenticationService,
@@ -62,7 +62,7 @@ class GetAccountLoginFormHandlerTest extends UnitTest
 
         $authenticationService->method('hasIdentity')->willReturn(false);
 
-        $handler = new GetAccountLoginFormHandler(
+        $handler = new GetLoginAccountFormHandler(
             $router,
             $template,
             $authenticationService,

--- a/test/Unit/Admin/Handler/Account/GetAccountLogoutHandlerTest.php
+++ b/test/Unit/Admin/Handler/Account/GetAccountLogoutHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AdminTest\Unit\Admin\Handler\Account;
 
-use Admin\Admin\Handler\Account\GetAccountLogoutHandler;
+use Admin\Admin\Handler\Account\GetLogoutAccountHandler;
 use AdminTest\Unit\UnitTest;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Authentication\AuthenticationServiceInterface;
@@ -23,7 +23,7 @@ class GetAccountLogoutHandlerTest extends UnitTest
         $authenticationService = $this->createMock(AuthenticationServiceInterface::class);
         $request               = $this->createMock(ServerRequestInterface::class);
 
-        $handler = new GetAccountLogoutHandler(
+        $handler = new GetLogoutAccountHandler(
             $router,
             $authenticationService,
         );

--- a/test/Unit/Admin/Handler/Account/PostAccountChangePasswordHandlerTest.php
+++ b/test/Unit/Admin/Handler/Account/PostAccountChangePasswordHandlerTest.php
@@ -6,7 +6,7 @@ namespace AdminTest\Unit\Admin\Handler\Account;
 
 use Admin\Admin\Form\AccountForm;
 use Admin\Admin\Form\ChangePasswordForm;
-use Admin\Admin\Handler\Account\PostAccountChangePasswordHandler;
+use Admin\Admin\Handler\Account\PostChangeAccountPasswordHandler;
 use Admin\Admin\Service\AdminServiceInterface;
 use AdminTest\Unit\UnitTest;
 use Core\Admin\Entity\Admin;
@@ -76,7 +76,7 @@ class PostAccountChangePasswordHandlerTest extends UnitTest
         $this->accountForm->method('prepare')->willReturn('<form></form>');
         $this->changePasswordForm->method('prepare')->willReturn('<form></form>');
 
-        $handler = new PostAccountChangePasswordHandler(
+        $handler = new PostChangeAccountPasswordHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -110,7 +110,7 @@ class PostAccountChangePasswordHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::INVALID_CURRENT_PASSWORD);
 
-        $handler = new PostAccountChangePasswordHandler(
+        $handler = new PostChangeAccountPasswordHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -144,7 +144,7 @@ class PostAccountChangePasswordHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::AN_ERROR_OCCURRED);
 
-        $handler = new PostAccountChangePasswordHandler(
+        $handler = new PostChangeAccountPasswordHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -177,7 +177,7 @@ class PostAccountChangePasswordHandlerTest extends UnitTest
             ->method('addSuccess')
             ->with(Message::ACCOUNT_UPDATED);
 
-        $handler = new PostAccountChangePasswordHandler(
+        $handler = new PostChangeAccountPasswordHandler(
             $this->adminService,
             $this->router,
             $this->template,

--- a/test/Unit/Admin/Handler/Account/PostAccountEditHandlerTest.php
+++ b/test/Unit/Admin/Handler/Account/PostAccountEditHandlerTest.php
@@ -6,7 +6,7 @@ namespace AdminTest\Unit\Admin\Handler\Account;
 
 use Admin\Admin\Form\AccountForm;
 use Admin\Admin\Form\ChangePasswordForm;
-use Admin\Admin\Handler\Account\PostAccountEditHandler;
+use Admin\Admin\Handler\Account\PostEditAccountHandler;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\ConflictException;
 use AdminTest\Unit\UnitTest;
@@ -72,7 +72,7 @@ class PostAccountEditHandlerTest extends UnitTest
         $this->authenticationService->method('getIdentity')->willReturn($this->identity);
         $this->accountForm->method('isValid')->willReturn(false);
 
-        $handler = new PostAccountEditHandler(
+        $handler = new PostEditAccountHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -107,7 +107,7 @@ class PostAccountEditHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::DUPLICATE_IDENTITY);
 
-        $handler = new PostAccountEditHandler(
+        $handler = new PostEditAccountHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -139,7 +139,7 @@ class PostAccountEditHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::AN_ERROR_OCCURRED);
 
-        $handler = new PostAccountEditHandler(
+        $handler = new PostEditAccountHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -171,7 +171,7 @@ class PostAccountEditHandlerTest extends UnitTest
             ->method('addSuccess')
             ->with(Message::ACCOUNT_UPDATED);
 
-        $handler = new PostAccountEditHandler(
+        $handler = new PostEditAccountHandler(
             $this->adminService,
             $this->router,
             $this->template,

--- a/test/Unit/Admin/Handler/Account/PostAccountLoginHandlerTest.php
+++ b/test/Unit/Admin/Handler/Account/PostAccountLoginHandlerTest.php
@@ -6,7 +6,7 @@ namespace AdminTest\Unit\Admin\Handler\Account;
 
 use Admin\Admin\Adapter\AuthenticationAdapter;
 use Admin\Admin\Form\LoginForm;
-use Admin\Admin\Handler\Account\PostAccountLoginHandler;
+use Admin\Admin\Handler\Account\PostLoginAccountHandler;
 use Admin\Admin\Service\AdminLoginServiceInterface;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Plugin\FormsPlugin;
@@ -83,7 +83,7 @@ class PostAccountLoginHandlerTest extends UnitTest
     {
         $this->authenticationService->method('hasIdentity')->willReturn(true);
 
-        $handler = new PostAccountLoginHandler(
+        $handler = new PostLoginAccountHandler(
             $this->adminService,
             $this->adminLoginService,
             $this->router,
@@ -120,7 +120,7 @@ class PostAccountLoginHandlerTest extends UnitTest
             ->expects($this->atLeastOnce())
             ->method('addError');
 
-        $handler = new PostAccountLoginHandler(
+        $handler = new PostLoginAccountHandler(
             $this->adminService,
             $this->adminLoginService,
             $this->router,
@@ -157,7 +157,7 @@ class PostAccountLoginHandlerTest extends UnitTest
         $this->messenger->expects($this->atLeastOnce())->method('addError');
         $this->adminLoginService->expects($this->atLeastOnce())->method('logFailedLogin');
 
-        $handler = new PostAccountLoginHandler(
+        $handler = new PostLoginAccountHandler(
             $this->adminService,
             $this->adminLoginService,
             $this->router,
@@ -204,7 +204,7 @@ class PostAccountLoginHandlerTest extends UnitTest
             ->expects($this->atLeastOnce())
             ->method('clearIdentity');
 
-        $handler = new PostAccountLoginHandler(
+        $handler = new PostLoginAccountHandler(
             $this->adminService,
             $this->adminLoginService,
             $this->router,
@@ -234,7 +234,7 @@ class PostAccountLoginHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::AN_ERROR_OCCURRED);
 
-        $handler = new PostAccountLoginHandler(
+        $handler = new PostLoginAccountHandler(
             $this->adminService,
             $this->adminLoginService,
             $this->router,
@@ -276,7 +276,7 @@ class PostAccountLoginHandlerTest extends UnitTest
         $this->adminLoginService->expects($this->atLeastOnce())->method('logSuccessfulLogin');
         $this->storage->expects($this->atLeastOnce())->method('write')->with($this->identity);
 
-        $handler = new PostAccountLoginHandler(
+        $handler = new PostLoginAccountHandler(
             $this->adminService,
             $this->adminLoginService,
             $this->router,

--- a/test/Unit/Admin/Handler/Admin/GetAdminCreateFormHandlerTest.php
+++ b/test/Unit/Admin/Handler/Admin/GetAdminCreateFormHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AdminTest\Unit\Admin\Handler\Admin;
 
 use Admin\Admin\Form\CreateAdminForm;
-use Admin\Admin\Handler\Admin\GetAdminCreateFormHandler;
+use Admin\Admin\Handler\Admin\GetCreateAdminFormHandler;
 use AdminTest\Unit\UnitTest;
 use Fig\Http\Message\StatusCodeInterface;
 use Mezzio\Router\RouterInterface;
@@ -25,7 +25,7 @@ class GetAdminCreateFormHandlerTest extends UnitTest
         $form     = $this->createMock(CreateAdminForm::class);
         $request  = $this->createMock(ServerRequestInterface::class);
 
-        $handler = new GetAdminCreateFormHandler(
+        $handler = new GetCreateAdminFormHandler(
             $router,
             $template,
             $form,

--- a/test/Unit/Admin/Handler/Admin/GetAdminDeleteFormHandlerTest.php
+++ b/test/Unit/Admin/Handler/Admin/GetAdminDeleteFormHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AdminTest\Unit\Admin\Handler\Admin;
 
 use Admin\Admin\Form\DeleteAdminForm;
-use Admin\Admin\Handler\Admin\GetAdminDeleteFormHandler;
+use Admin\Admin\Handler\Admin\GetDeleteAdminFormHandler;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
 use AdminTest\Unit\UnitTest;
@@ -51,7 +51,7 @@ class GetAdminDeleteFormHandlerTest extends UnitTest
 
         $this->messenger->expects($this->once())->method('addError')->with(Message::ADMIN_NOT_FOUND);
 
-        $handler = new GetAdminDeleteFormHandler(
+        $handler = new GetDeleteAdminFormHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -82,7 +82,7 @@ class GetAdminDeleteFormHandlerTest extends UnitTest
         $this->router->method('generateUri')->willReturn('/');
         $this->template->method('render')->willReturn('<p></p>');
 
-        $handler = new GetAdminDeleteFormHandler(
+        $handler = new GetDeleteAdminFormHandler(
             $this->adminService,
             $this->router,
             $this->template,

--- a/test/Unit/Admin/Handler/Admin/GetAdminEditFormHandlerTest.php
+++ b/test/Unit/Admin/Handler/Admin/GetAdminEditFormHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AdminTest\Unit\Admin\Handler\Admin;
 
 use Admin\Admin\Form\EditAdminForm;
-use Admin\Admin\Handler\Admin\GetAdminEditFormHandler;
+use Admin\Admin\Handler\Admin\GetEditAdminFormHandler;
 use Admin\Admin\Service\AdminRoleServiceInterface;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
@@ -59,7 +59,7 @@ class GetAdminEditFormHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::ADMIN_NOT_FOUND);
 
-        $handler = new GetAdminEditFormHandler(
+        $handler = new GetEditAdminFormHandler(
             $this->adminService,
             $this->adminRoleService,
             $this->router,
@@ -92,7 +92,7 @@ class GetAdminEditFormHandlerTest extends UnitTest
 
         $this->template->method('render')->willReturn('<p></p>');
 
-        $handler = new GetAdminEditFormHandler(
+        $handler = new GetEditAdminFormHandler(
             $this->adminService,
             $this->adminRoleService,
             $this->router,

--- a/test/Unit/Admin/Handler/Admin/GetAdminListHandlerTest.php
+++ b/test/Unit/Admin/Handler/Admin/GetAdminListHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AdminTest\Unit\Admin\Handler\Admin;
 
-use Admin\Admin\Handler\Admin\GetAdminListHandler;
+use Admin\Admin\Handler\Admin\GetListAdminHandler;
 use Admin\Admin\Service\AdminServiceInterface;
 use AdminTest\Unit\UnitTest;
 use Core\Admin\Entity\Admin;
@@ -37,7 +37,7 @@ class GetAdminListHandlerTest extends UnitTest
 
         $adminService->method('getAdminRepository')->willReturn($adminRepository);
 
-        $handler = new GetAdminListHandler($adminService, $template);
+        $handler = new GetListAdminHandler($adminService, $template);
 
         $response = $handler->handle($request);
 

--- a/test/Unit/Admin/Handler/Admin/GetAdminLoginListHandlerTest.php
+++ b/test/Unit/Admin/Handler/Admin/GetAdminLoginListHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AdminTest\Unit\Admin\Handler\Admin;
 
-use Admin\Admin\Handler\Admin\GetAdminLoginListHandler;
+use Admin\Admin\Handler\Admin\GetListAdminLoginHandler;
 use Admin\Admin\Service\AdminLoginServiceInterface;
 use AdminTest\Unit\UnitTest;
 use Fig\Http\Message\StatusCodeInterface;
@@ -26,7 +26,7 @@ class GetAdminLoginListHandlerTest extends UnitTest
         $request->method('getQueryParams')->willReturn([]);
         $adminLoginService->method('getAdminLogins')->willReturn([]);
 
-        $handler  = new GetAdminLoginListHandler($adminLoginService, $template);
+        $handler  = new GetListAdminLoginHandler($adminLoginService, $template);
         $response = $handler->handle($request);
 
         $this->assertSame($response->getHeaderLine('content-type'), 'text/html; charset=utf-8');

--- a/test/Unit/Admin/Handler/Admin/PostAdminCreateHandlerTest.php
+++ b/test/Unit/Admin/Handler/Admin/PostAdminCreateHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AdminTest\Unit\Admin\Handler\Admin;
 
 use Admin\Admin\Form\CreateAdminForm;
-use Admin\Admin\Handler\Admin\PostAdminCreateHandler;
+use Admin\Admin\Handler\Admin\PostCreateAdminHandler;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\ConflictException;
 use AdminTest\Unit\UnitTest;
@@ -65,7 +65,7 @@ class PostAdminCreateHandlerTest extends UnitTest
             ->method('addSuccess')
             ->with(Message::ADMIN_CREATED);
 
-        $handler = new PostAdminCreateHandler(
+        $handler = new PostCreateAdminHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -85,7 +85,7 @@ class PostAdminCreateHandlerTest extends UnitTest
         $this->adminForm->method('isValid')->willReturn(false);
         $this->adminForm->method('getData')->willReturn([]);
 
-        $handler = new PostAdminCreateHandler(
+        $handler = new PostCreateAdminHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -106,7 +106,7 @@ class PostAdminCreateHandlerTest extends UnitTest
 
         $this->throwException(new ConflictException());
 
-        $handler = new PostAdminCreateHandler(
+        $handler = new PostCreateAdminHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -127,7 +127,7 @@ class PostAdminCreateHandlerTest extends UnitTest
 
         $this->throwException(new Exception());
 
-        $handler = new PostAdminCreateHandler(
+        $handler = new PostCreateAdminHandler(
             $this->adminService,
             $this->router,
             $this->template,

--- a/test/Unit/Admin/Handler/Admin/PostAdminDeleteHandlerTest.php
+++ b/test/Unit/Admin/Handler/Admin/PostAdminDeleteHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AdminTest\Unit\Admin\Handler\Admin;
 
 use Admin\Admin\Form\DeleteAdminForm;
-use Admin\Admin\Handler\Admin\PostAdminDeleteHandler;
+use Admin\Admin\Handler\Admin\PostDeleteAdminHandler;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
 use AdminTest\Unit\UnitTest;
@@ -66,7 +66,7 @@ class PostAdminDeleteHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::ADMIN_NOT_FOUND);
 
-        $handler = new PostAdminDeleteHandler(
+        $handler = new PostDeleteAdminHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -105,7 +105,7 @@ class PostAdminDeleteHandlerTest extends UnitTest
 
         $this->adminService->expects($this->once())->method('deleteAdmin')->with($admin);
 
-        $handler = new PostAdminDeleteHandler(
+        $handler = new PostDeleteAdminHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -137,7 +137,7 @@ class PostAdminDeleteHandlerTest extends UnitTest
         $this->form->method('isValid')->willReturn(false);
         $this->form->method('getData')->willReturn([]);
 
-        $handler = new PostAdminDeleteHandler(
+        $handler = new PostDeleteAdminHandler(
             $this->adminService,
             $this->router,
             $this->template,
@@ -166,7 +166,7 @@ class PostAdminDeleteHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::AN_ERROR_OCCURRED);
 
-        $handler = new PostAdminDeleteHandler(
+        $handler = new PostDeleteAdminHandler(
             $this->adminService,
             $this->router,
             $this->template,

--- a/test/Unit/Admin/Handler/Admin/PostAdminEditHandlerTest.php
+++ b/test/Unit/Admin/Handler/Admin/PostAdminEditHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AdminTest\Unit\Admin\Handler\Admin;
 
 use Admin\Admin\Form\EditAdminForm;
-use Admin\Admin\Handler\Admin\PostAdminEditHandler;
+use Admin\Admin\Handler\Admin\PostEditAdminHandler;
 use Admin\Admin\Service\AdminRoleServiceInterface;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\ConflictException;
@@ -76,7 +76,7 @@ class PostAdminEditHandlerTest extends UnitTest
             ->method('addError')
             ->with(Message::ADMIN_NOT_FOUND);
 
-        $handler = new PostAdminEditHandler(
+        $handler = new PostEditAdminHandler(
             $this->adminService,
             $this->adminRoleService,
             $this->router,
@@ -113,7 +113,7 @@ class PostAdminEditHandlerTest extends UnitTest
 
         $this->adminService->expects($this->once())->method('saveAdmin');
 
-        $handler = new PostAdminEditHandler(
+        $handler = new PostEditAdminHandler(
             $this->adminService,
             $this->adminRoleService,
             $this->router,
@@ -142,7 +142,7 @@ class PostAdminEditHandlerTest extends UnitTest
         $this->form->method('isValid')->willReturn(false);
         $this->form->method('getData')->willReturn([]);
 
-        $handler = new PostAdminEditHandler(
+        $handler = new PostEditAdminHandler(
             $this->adminService,
             $this->adminRoleService,
             $this->router,
@@ -168,7 +168,7 @@ class PostAdminEditHandlerTest extends UnitTest
         $this->form->method('isValid')->willReturn(false);
         $this->form->method('getData')->willReturn([]);
 
-        $handler = new PostAdminEditHandler(
+        $handler = new PostEditAdminHandler(
             $this->adminService,
             $this->adminRoleService,
             $this->router,
@@ -196,7 +196,7 @@ class PostAdminEditHandlerTest extends UnitTest
         $this->form->method('isValid')->willReturn(false);
         $this->form->method('getData')->willReturn([]);
 
-        $handler = new PostAdminEditHandler(
+        $handler = new PostEditAdminHandler(
             $this->adminService,
             $this->adminRoleService,
             $this->router,

--- a/test/Unit/Dashboard/Handler/GetDashboardViewHandlerTest.php
+++ b/test/Unit/Dashboard/Handler/GetDashboardViewHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AdminTest\Unit\Dashboard\Handler;
 
-use Admin\Dashboard\Handler\GetDashboardViewHandler;
+use Admin\Dashboard\Handler\GetViewDashboardHandler;
 use AdminTest\Unit\UnitTest;
 use Fig\Http\Message\StatusCodeInterface;
 use Mezzio\Router\RouteResult;
@@ -31,7 +31,7 @@ class GetDashboardViewHandlerTest extends UnitTest
             ->with(RouteResult::class)
             ->willReturn($routeResult);
 
-        $handler = new GetDashboardViewHandler($template);
+        $handler = new GetViewDashboardHandler($template);
 
         $response = $handler->handle($request);
 

--- a/test/Unit/Page/Handler/GetPageViewHandlerTest.php
+++ b/test/Unit/Page/Handler/GetPageViewHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AdminTest\Unit\Page\Handler;
 
-use Admin\Page\Handler\GetPageViewHandler;
+use Admin\Page\Handler\GetViewPageHandler;
 use AdminTest\Unit\UnitTest;
 use Fig\Http\Message\StatusCodeInterface;
 use Mezzio\Router\RouteResult;
@@ -31,7 +31,7 @@ class GetPageViewHandlerTest extends UnitTest
             ->with(RouteResult::class)
             ->willReturn($routeResult);
 
-        $handler = new GetPageViewHandler($template);
+        $handler = new GetViewPageHandler($template);
 
         $response = $handler->handle($request);
 

--- a/test/Unit/Setting/ConfigProviderTest.php
+++ b/test/Unit/Setting/ConfigProviderTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace AdminTest\Unit\Setting;
 
 use Admin\Setting\ConfigProvider;
-use Admin\Setting\Handler\GetSettingViewHandler;
-use Admin\Setting\Handler\PostSettingStoreHandler;
+use Admin\Setting\Handler\GetViewSettingHandler;
+use Admin\Setting\Handler\PostStoreSettingHandler;
 use Admin\Setting\RoutesDelegator;
 use Admin\Setting\Service\SettingService;
 use Admin\Setting\Service\SettingServiceInterface;
@@ -44,8 +44,8 @@ class ConfigProviderTest extends UnitTest
     public function testDependenciesHasFactories(): void
     {
         $this->assertArrayHasKey('factories', $this->config['dependencies']);
-        $this->assertArrayHasKey(PostSettingStoreHandler::class, $this->config['dependencies']['factories']);
-        $this->assertArrayHasKey(GetSettingViewHandler::class, $this->config['dependencies']['factories']);
+        $this->assertArrayHasKey(PostStoreSettingHandler::class, $this->config['dependencies']['factories']);
+        $this->assertArrayHasKey(GetViewSettingHandler::class, $this->config['dependencies']['factories']);
         $this->assertArrayHasKey(SettingService::class, $this->config['dependencies']['factories']);
     }
 

--- a/test/Unit/Setting/Handler/GetSettingHandlerTest.php
+++ b/test/Unit/Setting/Handler/GetSettingHandlerTest.php
@@ -7,7 +7,7 @@ namespace AdminTest\Unit\Setting\Handler;
 use Admin\Admin\Service\AdminService;
 use Admin\Admin\Service\AdminServiceInterface;
 use Admin\App\Exception\NotFoundException;
-use Admin\Setting\Handler\GetSettingViewHandler;
+use Admin\Setting\Handler\GetViewSettingHandler;
 use Admin\Setting\Service\SettingService;
 use Admin\Setting\Service\SettingServiceInterface;
 use AdminTest\Unit\UnitTest;
@@ -32,13 +32,13 @@ class GetSettingHandlerTest extends UnitTest
      */
     public function testWillCreate(): void
     {
-        $handler = new GetSettingViewHandler(
+        $handler = new GetViewSettingHandler(
             $this->createMock(AuthenticationServiceInterface::class),
             $this->createMock(AdminService::class),
             $this->createMock(SettingService::class),
         );
 
-        $this->assertSame(GetSettingViewHandler::class, $handler::class);
+        $this->assertSame(GetViewSettingHandler::class, $handler::class);
     }
 
     /**
@@ -51,7 +51,7 @@ class GetSettingHandlerTest extends UnitTest
         $settingService        = $this->createMock(SettingService::class);
         $request               = $this->createMock(ServerRequestInterface::class);
 
-        $handler = new GetSettingViewHandler(
+        $handler = new GetViewSettingHandler(
             $authenticationService,
             $adminService,
             $settingService,
@@ -92,7 +92,7 @@ class GetSettingHandlerTest extends UnitTest
             ->with('identifier')
             ->willReturn(SettingIdentifierEnum::IdentifierTableAdminListSelectedColumns->value);
 
-        $handler = new GetSettingViewHandler(
+        $handler = new GetViewSettingHandler(
             $authenticationService,
             $adminService,
             $settingService,
@@ -132,7 +132,7 @@ class GetSettingHandlerTest extends UnitTest
             ->with('identifier')
             ->willReturn(SettingIdentifierEnum::IdentifierTableAdminListSelectedColumns->value);
 
-        $handler = new GetSettingViewHandler(
+        $handler = new GetViewSettingHandler(
             $authenticationService,
             $adminService,
             $settingService,
@@ -180,7 +180,7 @@ class GetSettingHandlerTest extends UnitTest
             ->with('identifier')
             ->willReturn(SettingIdentifierEnum::IdentifierTableAdminListSelectedColumns->value);
 
-        $handler = new GetSettingViewHandler(
+        $handler = new GetViewSettingHandler(
             $authenticationService,
             $adminService,
             $settingService,

--- a/test/Unit/Setting/Handler/StoreSettingHandlerTest.php
+++ b/test/Unit/Setting/Handler/StoreSettingHandlerTest.php
@@ -6,7 +6,7 @@ namespace AdminTest\Unit\Setting\Handler;
 
 use Admin\Admin\Service\AdminService;
 use Admin\App\Exception\NotFoundException;
-use Admin\Setting\Handler\PostSettingStoreHandler;
+use Admin\Setting\Handler\PostStoreSettingHandler;
 use Admin\Setting\Service\SettingService;
 use AdminTest\Unit\UnitTest;
 use Core\Admin\Entity\Admin;
@@ -53,13 +53,13 @@ class StoreSettingHandlerTest extends UnitTest
 
     public function testWillCreate(): void
     {
-        $handler = new PostSettingStoreHandler(
+        $handler = new PostStoreSettingHandler(
             $this->authenticationService,
             $this->adminService,
             $this->settingService,
         );
 
-        $this->assertSame(PostSettingStoreHandler::class, $handler::class);
+        $this->assertSame(PostStoreSettingHandler::class, $handler::class);
     }
 
     /**
@@ -67,7 +67,7 @@ class StoreSettingHandlerTest extends UnitTest
      */
     public function testInvalidIdentifierProvided(): void
     {
-        $handler = new PostSettingStoreHandler(
+        $handler = new PostStoreSettingHandler(
             $this->authenticationService,
             $this->adminService,
             $this->settingService,
@@ -116,7 +116,7 @@ class StoreSettingHandlerTest extends UnitTest
         $this->request->method('getAttribute')->with('identifier')->willReturn('test');
         $this->request->method('getBody')->willReturn($this->stream);
 
-        $handler = new PostSettingStoreHandler(
+        $handler = new PostStoreSettingHandler(
             $this->authenticationService,
             $this->adminService,
             $this->settingService,
@@ -159,7 +159,7 @@ class StoreSettingHandlerTest extends UnitTest
             ->with('identifier')
             ->willReturn(SettingIdentifierEnum::IdentifierTableAdminListSelectedColumns->value);
 
-        $handler = new PostSettingStoreHandler(
+        $handler = new PostStoreSettingHandler(
             $this->authenticationService,
             $this->adminService,
             $this->settingService,


### PR DESCRIPTION
A few notes:

- kept the existing HTTP verb, similar to API handlers ( `PostCreateAdminHandler` instead of `CreateAdminHandler`)
- kept the "admin-account" naming convention for the `Admin\Handler\Account` handlers although it doesn't exactly match the route names:

```php
        $routeCollector->get('/admin/login', GetLoginAccountFormHandler::class, 'admin::login-admin-form');
        $routeCollector->post('/admin/login', PostLoginAccountHandler::class, 'admin::login-admin');
        $routeCollector->get('/admin/logout', GetLogoutAccountHandler::class, 'admin::logout-admin');
```

Closes #376 