### PR TITLE
Form updates

### DIFF
--- a/src/Admin/src/Form/CreateAdminForm.php
+++ b/src/Admin/src/Form/CreateAdminForm.php
@@ -13,6 +13,7 @@ use Laminas\Form\Element\Password;
 use Laminas\Form\Element\Select;
 use Laminas\Form\Element\Submit;
 use Laminas\Form\Element\Text;
+use Laminas\Form\Exception\ExceptionInterface;
 use Laminas\Session\Container;
 
 /**
@@ -24,6 +25,7 @@ class CreateAdminForm extends AbstractForm
 {
     /**
      * @param array<non-empty-string, mixed> $options
+     * @throws ExceptionInterface
      */
     public function __construct(?string $name = null, array $options = [])
     {
@@ -41,16 +43,20 @@ class CreateAdminForm extends AbstractForm
 
     /**
      * @phpstan-param SelectDataType[] $roles
+     * @throws ExceptionInterface
      */
-    public function setRoles(array $roles): self
+    public function setRoles(array $roles): static
     {
-        return $this->add(
-            (new MultiCheckbox('roles'))
-                ->setLabel('Select at least one role')
-                ->setValueOptions($roles)
-        );
+        $checkbox = new MultiCheckbox('roles');
+        $checkbox->setLabel('Select at least one role');
+        $checkbox->setValueOptions($roles);
+        $this->add($checkbox);
+        return $this;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function init(): void
     {
         $this->add(
@@ -76,12 +82,13 @@ class CreateAdminForm extends AbstractForm
             (new Text('lastName'))
                 ->setLabel('Lastname')
         );
-        $this->add(
-            (new Select('status'))
-                ->setLabel('Account status')
-                ->setValueOptions(AdminStatusEnum::toArray())
-                ->setAttribute('required', true)
-        );
+
+        $select = new Select('status');
+        $select->setLabel('Account status');
+        $select->setValueOptions(AdminStatusEnum::toArray());
+        $select->setAttribute('required', true);
+        $this->add($select);
+
         $this->add(
             (new Csrf('adminCreateCsrf'))
                 ->setOptions([

--- a/src/Admin/src/Form/EditAdminForm.php
+++ b/src/Admin/src/Form/EditAdminForm.php
@@ -13,6 +13,7 @@ use Laminas\Form\Element\Password;
 use Laminas\Form\Element\Select;
 use Laminas\Form\Element\Submit;
 use Laminas\Form\Element\Text;
+use Laminas\Form\Exception\ExceptionInterface;
 use Laminas\Session\Container;
 
 /**
@@ -24,6 +25,7 @@ class EditAdminForm extends AbstractForm
 {
     /**
      * @param array<non-empty-string, mixed> $options
+     * @throws ExceptionInterface
      */
     public function __construct(?string $name = null, array $options = [])
     {
@@ -41,16 +43,20 @@ class EditAdminForm extends AbstractForm
 
     /**
      * @phpstan-param SelectDataType[] $roles
+     * @throws ExceptionInterface
      */
-    public function setRoles(array $roles): self
+    public function setRoles(array $roles): static
     {
-        return $this->add(
-            (new MultiCheckbox('roles'))
-                ->setLabel('Select at least one role')
-                ->setValueOptions($roles)
-        );
+        $checkbox = new MultiCheckbox('roles');
+        $checkbox->setLabel('Select at least one role');
+        $checkbox->setValueOptions($roles);
+        $this->add($checkbox);
+        return $this;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function init(): void
     {
         $this->add(
@@ -69,12 +75,13 @@ class EditAdminForm extends AbstractForm
             (new Text('lastName'))
                 ->setLabel('Lastname')
         );
-        $this->add(
-            (new Select('status'))
-                ->setLabel('Account status')
-                ->setValueOptions(AdminStatusEnum::toArray())
-                ->setAttribute('required', true)
-        );
+
+        $select = new Select('status');
+        $select->setLabel('Account status');
+        $select->setValueOptions(AdminStatusEnum::toArray());
+        $select->setAttribute('required', true);
+        $this->add($select);
+
         $this->add(
             (new Csrf('adminEditCsrf'))
                 ->setOptions([

--- a/src/Admin/src/Handler/Admin/GetEditAdminFormHandler.php
+++ b/src/Admin/src/Handler/Admin/GetEditAdminFormHandler.php
@@ -15,6 +15,7 @@ use Dot\FlashMessenger\FlashMessengerInterface;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Form\Exception\ExceptionInterface;
 use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -46,6 +47,9 @@ class GetEditAdminFormHandler implements RequestHandlerInterface
     ) {
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
@@ -59,7 +63,7 @@ class GetEditAdminFormHandler implements RequestHandlerInterface
         /** @var AdminRole[] $adminRoles */
         $adminRoles = $this->adminRoleService->getAdminRoleRepository()->findAll();
         $adminRoles = array_map(
-            /** @return SelectDataType */
+        /** @return SelectDataType */
             fn (AdminRole $adminRole): array => [
                 'label'    => $adminRole->getName()->value,
                 'value'    => $adminRole->getUuid()->toString(),
@@ -68,12 +72,11 @@ class GetEditAdminFormHandler implements RequestHandlerInterface
             $adminRoles
         );
 
-        $this->editAdminForm
-            ->setAttribute(
-                'action',
-                $this->router->generateUri('admin::edit-admin', ['uuid' => $admin->getUuid()->toString()])
-            )
-            ->bind($admin)
+        $this->editAdminForm->setAttribute(
+            'action',
+            $this->router->generateUri('admin::edit-admin', ['uuid' => $admin->getUuid()->toString()])
+        );
+        $this->editAdminForm->bind($admin)
             ->setRoles($adminRoles);
 
         return new HtmlResponse(

--- a/src/Admin/src/Handler/Admin/PostEditAdminHandler.php
+++ b/src/Admin/src/Handler/Admin/PostEditAdminHandler.php
@@ -20,6 +20,7 @@ use Dot\Log\Logger;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Form\Exception\ExceptionInterface;
 use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -55,6 +56,9 @@ class PostEditAdminHandler implements RequestHandlerInterface
     ) {
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
@@ -68,7 +72,7 @@ class PostEditAdminHandler implements RequestHandlerInterface
         /** @var AdminRole[] $adminRoles */
         $adminRoles = $this->adminRoleService->getAdminRoleRepository()->findAll();
         $adminRoles = array_map(
-            /** @return SelectDataType */
+        /** @return SelectDataType */
             fn (AdminRole $adminRole): array => [
                 'label'    => $adminRole->getName()->value,
                 'value'    => $adminRole->getUuid()->toString(),
@@ -77,12 +81,11 @@ class PostEditAdminHandler implements RequestHandlerInterface
             $adminRoles
         );
 
-        $this->editAdminForm
-            ->setAttribute(
-                'action',
-                $this->router->generateUri('admin::edit-admin', ['uuid' => $admin->getUuid()->toString()])
-            )
-            ->setRoles($adminRoles);
+        $this->editAdminForm->setAttribute(
+            'action',
+            $this->router->generateUri('admin::edit-admin', ['uuid' => $admin->getUuid()->toString()])
+        );
+        $this->editAdminForm->setRoles($adminRoles);
 
         try {
             /** @var iterable<array<string, string|string[]>> $data */

--- a/src/Admin/src/Service/AdminService.php
+++ b/src/Admin/src/Service/AdminService.php
@@ -107,7 +107,7 @@ class AdminService implements AdminServiceInterface
         if (array_key_exists('identity', $data) && $data['identity'] !== null && ! $admin->hasIdentity()) {
             $admin->setIdentity($data['identity']);
         }
-        if (array_key_exists('password', $data) && $data['password'] !== null) {
+        if (array_key_exists('password', $data) && $data['password'] !== null && $data['password'] !== '') {
             $admin->usePassword($data['password']);
         }
         if (array_key_exists('firstName', $data) && $data['firstName'] !== null) {

--- a/src/User/src/Form/CreateUserForm.php
+++ b/src/User/src/Form/CreateUserForm.php
@@ -14,6 +14,7 @@ use Laminas\Form\Element\Password;
 use Laminas\Form\Element\Select;
 use Laminas\Form\Element\Submit;
 use Laminas\Form\Element\Text;
+use Laminas\Form\Exception\ExceptionInterface;
 use Laminas\Form\Fieldset;
 use Laminas\Session\Container;
 
@@ -26,6 +27,7 @@ class CreateUserForm extends AbstractForm
 {
     /**
      * @param array<non-empty-string, mixed> $options
+     * @throws ExceptionInterface
      */
     public function __construct(?string $name = null, array $options = [])
     {
@@ -43,16 +45,20 @@ class CreateUserForm extends AbstractForm
 
     /**
      * @phpstan-param SelectDataType[] $roles
+     * @throws ExceptionInterface
      */
-    public function setRoles(array $roles): self
+    public function setRoles(array $roles): static
     {
-        return $this->add(
-            (new MultiCheckbox('roles'))
-                ->setLabel('Select at least one role')
-                ->setValueOptions($roles)
-        );
+        $checkbox = new MultiCheckbox('roles');
+        $checkbox->setLabel('Select at least one role');
+        $checkbox->setValueOptions($roles);
+        $this->add($checkbox);
+        return $this;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function init(): void
     {
         $this
@@ -67,11 +73,6 @@ class CreateUserForm extends AbstractForm
             )->add(
                 (new Password('passwordConfirm'))
                     ->setLabel('Password confirm')
-                    ->setAttribute('required', true)
-            )->add(
-                (new Select('status'))
-                    ->setLabel('Account status')
-                    ->setValueOptions(UserStatusEnum::toArray())
                     ->setAttribute('required', true)
             )->add(
                 (new Csrf('userCreateCsrf'))
@@ -100,5 +101,11 @@ class CreateUserForm extends AbstractForm
                             ->setAttribute('required', true)
                     )
             );
+
+        $select = new Select('status');
+        $select->setLabel('Account status');
+        $select->setValueOptions(UserStatusEnum::toArray());
+        $select->setAttribute('required', true);
+        $this->add($select);
     }
 }

--- a/src/User/src/Form/EditUserForm.php
+++ b/src/User/src/Form/EditUserForm.php
@@ -14,6 +14,7 @@ use Laminas\Form\Element\Password;
 use Laminas\Form\Element\Select;
 use Laminas\Form\Element\Submit;
 use Laminas\Form\Element\Text;
+use Laminas\Form\Exception\ExceptionInterface;
 use Laminas\Form\Fieldset;
 use Laminas\Session\Container;
 
@@ -26,6 +27,7 @@ class EditUserForm extends AbstractForm
 {
     /**
      * @param array<non-empty-string, mixed> $options
+     * @throws ExceptionInterface
      */
     public function __construct(?string $name = null, array $options = [])
     {
@@ -43,16 +45,20 @@ class EditUserForm extends AbstractForm
 
     /**
      * @phpstan-param SelectDataType[] $roles
+     * @throws ExceptionInterface
      */
-    public function setRoles(array $roles): self
+    public function setRoles(array $roles): static
     {
-        return $this->add(
-            (new MultiCheckbox('roles'))
-                ->setLabel('Select at least one role')
-                ->setValueOptions($roles)
-        );
+        $checkbox = new MultiCheckbox('roles');
+        $checkbox->setLabel('Select at least one role');
+        $checkbox->setValueOptions($roles);
+        $this->add($checkbox);
+        return $this;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function init(): void
     {
         $this
@@ -62,11 +68,6 @@ class EditUserForm extends AbstractForm
             )->add(
                 (new Password('passwordConfirm'))
                     ->setLabel('Password confirm')
-            )->add(
-                (new Select('status'))
-                    ->setLabel('Account status')
-                    ->setValueOptions(UserStatusEnum::toArray())
-                    ->setAttribute('required', true)
             )->add(
                 (new Csrf('userEditCsrf'))
                     ->setOptions([
@@ -93,5 +94,11 @@ class EditUserForm extends AbstractForm
                             ->setLabel('Email')
                     )
             );
+
+        $select = new Select('status');
+        $select->setLabel('Account status');
+        $select->setValueOptions(UserStatusEnum::toArray());
+        $select->setAttribute('required', true);
+        $this->add($select);
     }
 }

--- a/src/User/src/Handler/GetEditUserFormHandler.php
+++ b/src/User/src/Handler/GetEditUserFormHandler.php
@@ -17,6 +17,7 @@ use Dot\FlashMessenger\FlashMessengerInterface;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Form\Exception\ExceptionInterface;
 use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -51,6 +52,9 @@ class GetEditUserFormHandler implements RequestHandlerInterface
     ) {
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
@@ -64,7 +68,7 @@ class GetEditUserFormHandler implements RequestHandlerInterface
         /** @var UserRole[] $userRoles */
         $userRoles = $this->userRoleService->getUserRoleRepository()->findAll();
         $userRoles = array_map(
-            /** @return SelectDataType */
+        /** @return SelectDataType */
             fn (UserRole $userRole): array => [
                 'label'    => $userRole->getName()->value,
                 'value'    => $userRole->getUuid()->toString(),
@@ -84,8 +88,8 @@ class GetEditUserFormHandler implements RequestHandlerInterface
             ->setAttribute(
                 'action',
                 $this->router->generateUri('user::edit-user', ['uuid' => $user->getUuid()->toString()])
-            )
-            ->bind($user)
+            );
+        $this->editUserForm->bind($user)
             ->setRoles($userRoles);
 
         return new HtmlResponse(

--- a/src/User/src/Handler/PostEditUserAvatarHandler.php
+++ b/src/User/src/Handler/PostEditUserAvatarHandler.php
@@ -20,6 +20,7 @@ use Dot\Log\Logger;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Form\Exception\ExceptionInterface;
 use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -60,6 +61,9 @@ class PostEditUserAvatarHandler implements RequestHandlerInterface
     ) {
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
@@ -93,8 +97,8 @@ class PostEditUserAvatarHandler implements RequestHandlerInterface
             ->setAttribute(
                 'action',
                 $this->router->generateUri('user::edit-user', ['uuid' => $user->getUuid()->toString()])
-            )
-            ->setRoles($userRoles);
+            );
+        $this->editUserForm->setRoles($userRoles);
         try {
             $this->editUserAvatarForm->setData(
                 array_merge((array) $request->getParsedBody(), $request->getUploadedFiles())

--- a/src/User/src/Handler/PostEditUserHandler.php
+++ b/src/User/src/Handler/PostEditUserHandler.php
@@ -22,6 +22,7 @@ use Dot\Log\Logger;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Form\Exception\ExceptionInterface;
 use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -60,6 +61,9 @@ class PostEditUserHandler implements RequestHandlerInterface
     ) {
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         try {
@@ -73,7 +77,7 @@ class PostEditUserHandler implements RequestHandlerInterface
         /** @var UserRole[] $userRoles */
         $userRoles = $this->userRoleService->getUserRoleRepository()->findAll();
         $userRoles = array_map(
-            /** @return SelectDataType */
+        /** @return SelectDataType */
             fn (UserRole $userRole): array => [
                 'label'    => $userRole->getName()->value,
                 'value'    => $userRole->getUuid()->toString(),
@@ -89,12 +93,11 @@ class PostEditUserHandler implements RequestHandlerInterface
                 $this->router->generateUri('user::edit-user-avatar', ['uuid' => $user->getUuid()->toString()])
             );
 
-        $this->editUserForm
-            ->setAttribute(
-                'action',
-                $this->router->generateUri('user::edit-user', ['uuid' => $user->getUuid()->toString()])
-            )
-            ->setRoles($userRoles);
+        $this->editUserForm->setAttribute(
+            'action',
+            $this->router->generateUri('user::edit-user', ['uuid' => $user->getUuid()->toString()])
+        );
+        $this->editUserForm->setRoles($userRoles);
 
         try {
             /** @var iterable<array<string, string|string[]>> $data */

--- a/src/User/src/Service/UserService.php
+++ b/src/User/src/Service/UserService.php
@@ -167,7 +167,7 @@ class UserService implements UserServiceInterface
         if (array_key_exists('identity', $data) && $data['identity'] !== null && ! $user->hasIdentity()) {
             $user->setIdentity($data['identity']);
         }
-        if (array_key_exists('password', $data) && $data['password'] !== null) {
+        if (array_key_exists('password', $data) && $data['password'] !== null && $data['password'] !== '') {
             $user->usePassword($data['password']);
         }
         if (array_key_exists('hash', $data) && $data['hash'] !== null) {


### PR DESCRIPTION
Splitting PR #386 into separate issues.

This PR should fix the static-analysis failures introduced with the latest version of `laminas-form` - also fixed a minor issue found when testing: editing admins was allowing empty strings as passwords resulting in password wipes for unrelated edits (such as modifying a name only).