### PR TITLE
Removed mezzio/mezzio-tooling dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "filp/whoops": "^2.18.0",
         "laminas/laminas-coding-standard": "^3.1.0",
         "laminas/laminas-development-mode": "^3.13.0",
-        "mezzio/mezzio-tooling": "^2.10.1",
         "phpstan/phpstan": "^2.1.17",
         "phpstan/phpstan-doctrine": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.6",

--- a/config/autoload/session.global.php
+++ b/config/autoload/session.global.php
@@ -40,7 +40,7 @@ return [
         /**
          * Marks the cookie as accessible only through the HTTP protocol.
          */
-        'cookie_httponly' => false,
+        'cookie_httponly' => true,
 
         /**
          * Specifies the lifetime of the cookie in seconds which is sent to the browser.

--- a/config/autoload/session.global.php
+++ b/config/autoload/session.global.php
@@ -40,7 +40,7 @@ return [
         /**
          * Marks the cookie as accessible only through the HTTP protocol.
          */
-        'cookie_httponly' => true,
+        'cookie_httponly' => false,
 
         /**
          * Specifies the lifetime of the cookie in seconds which is sent to the browser.

--- a/config/config.php
+++ b/config/config.php
@@ -35,11 +35,6 @@ $aggregator = new Laminas\ConfigAggregator\ConfigAggregator([
     Mezzio\Router\ConfigProvider::class,
     Mezzio\Router\FastRouteRouter\ConfigProvider::class,
     Mezzio\Twig\ConfigProvider::class,
-    class_exists(Mezzio\Tooling\ConfigProvider::class)
-        ? Mezzio\Tooling\ConfigProvider::class
-        : function () {
-        return [];
-    },
 
     // Dotkernel packages
     Dot\Cache\ConfigProvider::class,


### PR DESCRIPTION
This dependency seems to be a left-over from an older version of admin, as it doesn't seem to be used anywhere at the moment. Removing it doesn't change anything at all, and the features it brings don't appear useful to this project, especially with `dot-maker` installed.

Tested on a fresh copy of `admin` in `development mode`.