### PR TITLE
minor phpstan fix

### DIFF
--- a/src/Admin/src/Adapter/AuthenticationAdapter.php
+++ b/src/Admin/src/Adapter/AuthenticationAdapter.php
@@ -76,8 +76,10 @@ class AuthenticationAdapter implements AdapterInterface
         /** Check for the authentication configuration */
         $this->validateConfig();
 
+        /** @var class-string $classString */
+        $classString = $this->config['orm_default']['identity_class'];
         /** Get the identity class object */
-        $repository = $this->entityManager->getRepository($this->config['orm_default']['identity_class']);
+        $repository = $this->entityManager->getRepository($classString);
 
         /** @var Admin $identityClass */
         $identityClass = $repository->findOneBy([


### PR DESCRIPTION
As [the validateConfig](https://github.com/dotkernel/admin/blob/7.0/src/Admin/src/Adapter/AuthenticationAdapter.php#L171) method already checks the `identity_class` key is a valid class string, another assertion does not seem necessary - simply annotating it as such should fix the issue.

Closes #428 